### PR TITLE
CIF-902 - Enforce 80% code coverage for CIF Connector GraphQL bundle

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: true
+        target: 80%
+        threshold: null
+        base: auto
+    patch:
+      default:
+        enabled: true
+        target: 80%
+        threshold: null
+        base: auto

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlQueryLanguageProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlQueryLanguageProviderTest.java
@@ -27,6 +27,7 @@ import com.adobe.cq.commerce.graphql.magento.GraphqlDataService;
 import com.adobe.cq.commerce.graphql.testing.Utils;
 
 import static com.adobe.cq.commerce.graphql.resource.GraphqlQueryLanguageProvider.VIRTUAL_PRODUCT_QUERY_LANGUAGE;
+import static org.junit.Assert.assertNull;
 
 public class GraphqlQueryLanguageProviderTest {
 
@@ -52,6 +53,8 @@ public class GraphqlQueryLanguageProviderTest {
 
         // mock query has limit = 20 and offset = 20 --> so we expect page 2 and limit 20
         Mockito.verify(graphqlDataService, Mockito.times(1)).searchProducts("gloves", Integer.valueOf(2), Integer.valueOf(20));
+
+        assertNull(queryLanguageProvider.findResources(null, jsonRequest, "whatever"));
     }
 
     @Test

--- a/bundles/cif-connector-graphql/src/test/resources/magento-graphql-products-search.json
+++ b/bundles/cif-connector-graphql/src/test/resources/magento-graphql-products-search.json
@@ -449,8 +449,12 @@
           "description": {
             "html": ""
           },
-          "image": null,
-          "thumbnail": null,
+          "image": {
+            "url": null
+          },
+          "thumbnail": {
+            "url": null
+          },
           "url_key": "sonja-insulated-jacket",
           "updated_at": "2018-11-22 14:36:01",
           "created_at": "2018-11-22 14:36:01",

--- a/bundles/cif-connector-graphql/src/test/resources/magento-graphql-simple-product.json
+++ b/bundles/cif-connector-graphql/src/test/resources/magento-graphql-simple-product.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "products": {
+      "total_count": 1,
+      "items": [
+        {
+          "__typename": "SimpleProduct",
+          "id": 1,
+          "sku": "24-MB01",
+          "name": "Joust Duffle Bag",
+          "description": {
+            "html": "The sporty Joust Duffle Bag can't be beat"
+          },
+          "image": {
+            "url": "http://hostname/pub/media/catalog/product/mb01-blue-0.jpg"
+          },
+          "thumbnail": {
+            "url": "http://hostname/pub/media/catalog/product/mb01-blue-0.jpg"
+          },
+          "url_key": "joust-duffle-bag",
+          "updated_at": "2019-05-21 11:54:47",
+          "created_at": "2019-05-21 11:54:47",
+          "price": {
+            "regularPrice": {
+              "amount": {
+                "currency": "USD",
+                "value": 34
+              }
+            }
+          },
+          "categories": [
+            {
+              "__typename": "CategoryTree",
+              "url_path": "coats"
+            },
+            {
+              "__typename": "CategoryTree",
+              "url_path": "coats/men"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -262,19 +262,9 @@
                                         <element>BUNDLE</element>
                                         <limits>
                                             <limit>
-                                                <counter>INSTRUCTION</counter>
+                                                <counter>BRANCH</counter>
                                                 <value>COVEREDRATIO</value>
-                                                <minimum>0.0</minimum>
-                                            </limit>
-                                        </limits>
-                                    </rule>
-                                    <rule>
-                                        <element>CLASS</element>
-                                        <limits>
-                                            <limit>
-                                                <counter>INSTRUCTION</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.0</minimum>
+                                                <minimum>0.6</minimum>
                                             </limit>
                                         </limits>
                                     </rule>


### PR DESCRIPTION
- enforced 60% code coverage for unit tests
- enforced 80% code coverage for codecov (unit + integration tests)
- extended unit tests to reach the expected coverage
- added IT for assets products finder

I also fixed an issue in the resource provider so that simple products (that is, Magento products without variants) also have a child `/image` resource.