### PR TITLE
CIF-925 - Deep reading of properties for GraphQL resource provider

### DIFF
--- a/bundles/cif-connector-graphql/pom.xml
+++ b/bundles/cif-connector-graphql/pom.xml
@@ -29,7 +29,7 @@
     <name>CIF Connector - GraphQL Bundle</name>
     <description>CIF GraphQL Connector for AEM Commerce authoring</description>
     <url>https://github.com/adobe/commerce-cif-connector/bundles/cif-connector-graphql</url>
-    
+
     <scm>
         <connection>scm:git:https://github.com/adobe/commerce-cif-connector</connection>
         <developerConnection>scm:git:git@github.com:adobe/commerce-cif-connector.git</developerConnection>
@@ -255,6 +255,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/CategoryResource.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/CategoryResource.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.DeepReadValueMapDecorator;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 
 import com.adobe.cq.commerce.api.CommerceConstants;
@@ -63,7 +64,7 @@ class CategoryResource extends SyntheticResource {
         } else {
             map.put(JcrConstants.JCR_TITLE, MAGENTO_GRAPHQL_PROVIDER);
         }
-        values = new ValueMapDecorator(map);
+        values = new DeepReadValueMapDecorator(this, new ValueMapDecorator(map));
     }
 
     @Override

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProvider.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProvider.java
@@ -53,6 +53,11 @@ class GraphqlResourceProvider<T> extends ResourceProvider<T> {
     public Resource getResource(ResolveContext<T> ctx, String path, ResourceContext resourceContext, Resource parent) {
         LOGGER.debug("getResource called for " + path);
 
+        // needed for testing, harmless during runtime
+        if (path.endsWith("/.")) {
+            path = path.substring(0, path.length() - 2);
+        }
+
         if (path.equals(root)) {
             Resource resource = ctx.getParentResourceProvider().getResource(
                 (ResolveContext) ctx.getParentResolveContext(), path, resourceContext, parent);

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProvider.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProvider.java
@@ -53,11 +53,6 @@ class GraphqlResourceProvider<T> extends ResourceProvider<T> {
     public Resource getResource(ResolveContext<T> ctx, String path, ResourceContext resourceContext, Resource parent) {
         LOGGER.debug("getResource called for " + path);
 
-        // needed for testing, harmless during runtime
-        if (path.endsWith("/.")) {
-            path = path.substring(0, path.length() - 2);
-        }
-
         if (path.equals(root)) {
             Resource resource = ctx.getParentResourceProvider().getResource(
                 (ResolveContext) ctx.getParentResolveContext(), path, resourceContext, parent);

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/ProductResource.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/ProductResource.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.DeepReadValueMapDecorator;
 
 import com.adobe.cq.commerce.api.CommerceConstants;
 import com.adobe.cq.commerce.api.Product;
@@ -93,7 +94,7 @@ class ProductResource extends SyntheticResource {
 
         map.put(CommerceConstants.PN_COMMERCE_TYPE, activeVariantSku != null ? VARIANT : PRODUCT);
 
-        values = new ValueMapDecorator(map);
+        values = new DeepReadValueMapDecorator(this, new ValueMapDecorator(map));
     }
 
     private Date convertToDate(String magentoDate) {

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/RootCategoryResource.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/RootCategoryResource.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.DeepReadValueMapDecorator;
 
 import com.adobe.cq.commerce.common.ValueMapDecorator;
 
@@ -58,7 +59,7 @@ class RootCategoryResource extends ResourceWrapper {
         map.put(PN_COMMERCE_TYPE, CATEGORY);
         map.put(CIF_ID, rootCategoryId);
 
-        return new ValueMapDecorator(Collections.unmodifiableMap(map));
+        return new DeepReadValueMapDecorator(this, new ValueMapDecorator(Collections.unmodifiableMap(map)));
     }
 
     @Override

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/SyntheticImageResource.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/SyntheticImageResource.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.DeepReadValueMapDecorator;
 
 import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.day.cq.commons.DownloadResource;
@@ -44,7 +45,7 @@ public class SyntheticImageResource extends ImageResource {
             {
                 Map<String, Object> values = new HashMap<>();
                 values.put(DownloadResource.PN_REFERENCE, url);
-                valueMap = new ValueMapDecorator(values);
+                valueMap = new DeepReadValueMapDecorator(this, new ValueMapDecorator(values));
             }
 
             @Override

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -134,6 +134,10 @@ public class GraphqlResourceProviderTest {
         provider = new GraphqlResourceProvider<>(CATALOG_ROOT_PATH, dataService, scheduler);
         when(resourceResolver.getResource(any())).then(invocationOnMock -> {
             String path = (String) invocationOnMock.getArguments()[0];
+            if (path.endsWith("/.")) {
+                path = path.substring(0, path.length() - 2);
+            }
+
             return provider.getResource(resolveContext, path, null, null);
         });
     }


### PR DESCRIPTION
 * implemented feature
 * updated unit tests

## Description

As a developer I want support for deep reading of resource properties for GraphQL catalog resources so that category and product resource properties can be referred to as ./propertyName in resource property dialogs and product scaffolding.
This feature is available for the JCR resource provider in AEM and various sling components take it as granted, so it's important for the GraphQL resource provider to fill this gap.

## Related Issue
CIF-925

## How Has This Been Tested?
* manually
* unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
