### PR TITLE
CIF-946 - Add support for Omnisearch suggestions in product search

### DIFF
--- a/bundles/cif-connector-graphql/pom.xml
+++ b/bundles/cif-connector-graphql/pom.xml
@@ -263,7 +263,17 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
+            <version>1.4.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.testing</artifactId>
+            <version>2.0.16</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandler.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandler.java
@@ -86,7 +86,7 @@ public class ProductsSuggestionOmniSearchHandler extends AbstractOmniSearchHandl
         target = "(component.name=com.adobe.cq.commerce.impl.omnisearch.ProductsOmniSearchHandler)")
     private OmniSearchHandler productsOmniSearchHandler;
 
-    // This is never used, it id declared to "enforce" the dependency to Commerce Core
+    // This is never used, it is declared to "enforce" the dependency to Commerce Core
     // so that this bundle is always loaded or restarted AFTER the Commerce Core bundle
     // so we properly override the 'product' omnisearch handler
     @Reference

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandler.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandler.java
@@ -1,0 +1,330 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.omnisearch;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.ItemExistsException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.query.InvalidQueryException;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
+import javax.jcr.version.VersionException;
+
+import org.apache.jackrabbit.commons.iterator.RowIteratorAdapter;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.commerce.api.conf.CommerceBasePathsService;
+import com.adobe.granite.omnisearch.commons.AbstractOmniSearchHandler;
+import com.adobe.granite.omnisearch.spi.core.OmniSearchHandler;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.search.QueryBuilder;
+import com.day.cq.search.result.SearchResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component(immediate = true, service = OmniSearchHandler.class)
+public class ProductsSuggestionOmniSearchHandler extends AbstractOmniSearchHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProductsSuggestionOmniSearchHandler.class);
+
+    // We replace the legacy omnisearch component from Commerce Core
+    private static final String TYPE = "product";
+
+    private static final String VIRTUAL_PRODUCT_QUERY_LANGUAGE = "virtualProductOmnisearchQuery";
+    private static final String PARAMETER_OFFSET = "_commerce_offset";
+    private static final String PARAMETER_LIMIT = "_commerce_limit";
+
+    @Reference
+    private ResourceResolverFactory resolverFactory = null;
+
+    @Reference
+    private QueryBuilder queryBuilder = null;
+
+    // For the search, we reuse the legacy component from Commerce Core
+    @Reference(
+        cardinality = ReferenceCardinality.MANDATORY,
+        target = "(component.name=com.adobe.cq.commerce.impl.omnisearch.ProductsOmniSearchHandler)")
+    private OmniSearchHandler productsOmniSearchHandler;
+
+    // This is never used, it id declared to "enforce" the dependency to Commerce Core
+    // so that this bundle is always loaded or restarted AFTER the Commerce Core bundle
+    // so we properly override the 'product' omnisearch handler
+    @Reference
+    private CommerceBasePathsService cbps;
+
+    @Activate
+    protected void activate(ComponentContext componentContext) throws LoginException, PathNotFoundException, RepositoryException {
+        if (resolver == null) {
+            resolver = getResourceResolver();
+            init(resolver);
+            jsonMapper = new ObjectMapper();
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext componentContext) throws LoginException {
+        try {
+            destroy(resolver);
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Override
+    public String getID() {
+        return TYPE;
+    }
+
+    private ResourceResolver resolver;
+    private ObjectMapper jsonMapper;
+
+    @Override
+    public void onEvent(EventIterator eventIterator) {
+        if (resolver == null) {
+            try {
+                resolver = getResourceResolver();
+                init(resolver);
+                jsonMapper = new ObjectMapper();
+            } catch (LoginException e) {
+                LOGGER.error("Error initializing!", e);
+            }
+        }
+    }
+
+    @Override
+    public SearchResult getResults(ResourceResolver resolver, Map<String, Object> predicateParameters, long limit, long offset) {
+        return productsOmniSearchHandler.getResults(resolver, predicateParameters, limit, offset);
+    }
+
+    protected javax.jcr.query.Query getSuperSuggestionQuery(ResourceResolver resolver, String searchTerm) {
+        return super.getSuggestionQuery(resolver, searchTerm);
+    }
+
+    @Override
+    public javax.jcr.query.Query getSuggestionQuery(ResourceResolver resolver, String searchTerm) {
+        LOGGER.debug("Calling suggestion query with '{}'", searchTerm);
+        return new SuggestionQueryWrapper(getSuperSuggestionQuery(resolver, searchTerm), searchTerm);
+    }
+
+    Iterator<Resource> getVirtualResults(ResourceResolver resolver, Map<String, Object> predicateParameters, long limit, long offset) {
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.putAll(predicateParameters);
+        queryParameters.put(PARAMETER_OFFSET, String.valueOf(offset));
+        queryParameters.put(PARAMETER_LIMIT, String.valueOf(limit));
+        String queryString = mapToString(queryParameters);
+        Iterator<Resource> virtualResults = null;
+        try {
+            virtualResults = resolver.findResources(queryString, VIRTUAL_PRODUCT_QUERY_LANGUAGE);
+        } catch (Exception x) {
+            LOGGER.error("Error searching virtual products", x);
+        }
+        return virtualResults;
+    }
+
+    String mapToString(Map<String, Object> map) {
+        try {
+            return jsonMapper.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to serialize map data", e);
+            return null;
+        }
+    }
+
+    ResourceResolver getResourceResolver() throws LoginException {
+        Map<String, Object> param = new HashMap<>();
+        param.put(ResourceResolverFactory.SUBSERVICE, OMNI_SEARCH_SERVICE_USER);
+        return resolverFactory.getServiceResourceResolver(param);
+    }
+
+    private class SuggestionQueryWrapper implements javax.jcr.query.Query {
+
+        private SuggestionQueryWrapper(javax.jcr.query.Query query, String searchTerm) {
+            this.query = query;
+            this.searchTerm = searchTerm;
+        }
+
+        private javax.jcr.query.Query query;
+        private String searchTerm;
+
+        @Override
+        public QueryResult execute() throws InvalidQueryException, RepositoryException {
+            // Get JCR results
+            QueryResult queryResult = query.execute();
+
+            // Get CIF products
+            Iterator<Resource> it = getVirtualResults(resolver, Collections.singletonMap("fulltext", searchTerm), 10, 0);
+            if (it == null || !it.hasNext()) {
+                return queryResult; // No CIF results
+            }
+
+            ValueFactory valueFactory = resolver.adaptTo(Session.class).getValueFactory();
+            List<Row> rows = new ArrayList<>();
+            while (it.hasNext()) {
+                String title = it.next().getValueMap().get(JcrConstants.JCR_TITLE, String.class);
+                Value value = valueFactory.createValue(title);
+                rows.add(new SuggestionRow(value));
+            }
+
+            RowIterator suggestionIterator = queryResult.getRows();
+            while (suggestionIterator.hasNext()) {
+                rows.add(suggestionIterator.nextRow());
+            }
+
+            SuggestionQueryResult result = new SuggestionQueryResult(rows);
+            return result;
+        }
+
+        @Override
+        public void setLimit(long limit) {}
+
+        @Override
+        public void setOffset(long offset) {}
+
+        @Override
+        public String getStatement() {
+            return null;
+        }
+
+        @Override
+        public String getLanguage() {
+            return null;
+        }
+
+        @Override
+        public String getStoredQueryPath() throws ItemNotFoundException, RepositoryException {
+            return null;
+        }
+
+        @Override
+        public Node storeAsNode(String absPath) throws ItemExistsException, PathNotFoundException, VersionException,
+            ConstraintViolationException, LockException, UnsupportedRepositoryOperationException, RepositoryException {
+            return null;
+        }
+
+        @Override
+        public void bindValue(String varName, Value value) throws IllegalArgumentException, RepositoryException {}
+
+        @Override
+        public String[] getBindVariableNames() throws RepositoryException {
+            return null;
+        }
+    }
+
+    private class SuggestionQueryResult implements QueryResult {
+
+        private List<Row> rows;
+
+        private SuggestionQueryResult(List<Row> rows) {
+            this.rows = rows;
+        }
+
+        @Override
+        public String[] getColumnNames() throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public RowIterator getRows() throws RepositoryException {
+            return new RowIteratorAdapter(rows.iterator());
+        }
+
+        @Override
+        public NodeIterator getNodes() throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public String[] getSelectorNames() throws RepositoryException {
+            return null;
+        }
+    }
+
+    private class SuggestionRow implements Row {
+
+        private Value value;
+
+        private SuggestionRow(Value value) {
+            this.value = value;
+        }
+
+        @Override
+        public Value[] getValues() throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public Value getValue(String columnName) throws ItemNotFoundException, RepositoryException {
+            return value;
+        }
+
+        @Override
+        public Node getNode() throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public Node getNode(String selectorName) throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public String getPath() throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public String getPath(String selectorName) throws RepositoryException {
+            return null;
+        }
+
+        @Override
+        public double getScore() throws RepositoryException {
+            return 0;
+        }
+
+        @Override
+        public double getScore(String selectorName) throws RepositoryException {
+            return 0;
+        }
+    }
+}

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandlerTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandlerTest.java
@@ -62,6 +62,7 @@ public class ProductsSuggestionOmniSearchHandlerTest {
         suggestionHandler.getResults(resolver, params, 20, 10);
 
         // Search is delegated to the legacy Commerce Core ProductsSuggestionOmniSearchHandler
+        Assert.assertEquals("product", suggestionHandler.getID());
         Mockito.verify(productsOmniSearchHandler).getResults(resolver, params, 20, 10);
     }
 
@@ -91,6 +92,8 @@ public class ProductsSuggestionOmniSearchHandlerTest {
             .thenReturn(Collections.singletonList((Resource) cifProduct).iterator());
 
         suggestionHandler.activate(null);
+        suggestionHandler.onEvent(null);
+
         Query suggestionQuery = suggestionHandler.getSuggestionQuery(resolver, "coats");
         QueryResult queryResult = suggestionQuery.execute();
         RowIterator rows = queryResult.getRows();
@@ -118,6 +121,8 @@ public class ProductsSuggestionOmniSearchHandlerTest {
         Assert.assertNull(row.getNode("whatever"));
         Assert.assertEquals(0d, row.getScore(), 0);
         Assert.assertEquals(0d, row.getScore("whatever"), 0);
+
+        suggestionHandler.deactivate(null);
     }
 
     @Test
@@ -133,9 +138,11 @@ public class ProductsSuggestionOmniSearchHandlerTest {
         Mockito.doReturn(jcrQuery).when(suggestionHandler).getSuperSuggestionQuery(resolver, "coats");
         Mockito.doReturn(resolver).when(suggestionHandler).getResourceResolver();
 
-        Mockito.when(resolver.findResources(Mockito.any(), Mockito.any())).thenReturn(Collections.emptyListIterator());
+        Mockito.when(resolver.findResources(Mockito.any(), Mockito.any())).thenThrow(new RuntimeException());
 
+        suggestionHandler.onEvent(null);
         suggestionHandler.activate(null);
+
         Query suggestionQuery = suggestionHandler.getSuggestionQuery(resolver, "coats");
         QueryResult queryResult = suggestionQuery.execute();
         RowIterator rows = queryResult.getRows();

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandlerTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandlerTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.omnisearch;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.jcr.Session;
+import javax.jcr.ValueFactory;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.commons.testing.jcr.MockNode;
+import org.apache.sling.commons.testing.jcr.MockValue;
+import org.apache.sling.commons.testing.sling.MockResource;
+import org.apache.sling.testing.mock.jcr.MockQueryResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import com.adobe.granite.omnisearch.spi.core.OmniSearchHandler;
+import com.day.cq.commons.jcr.JcrConstants;
+
+public class ProductsSuggestionOmniSearchHandlerTest {
+
+    private static final String EL_GORDO_DOWN_JACKET = "El Gordo Down Jacket";
+    private static final String BROOKLYN_COAT = "Brooklyn Coat";
+
+    private ProductsSuggestionOmniSearchHandler suggestionHandler;
+    private ResourceResolver resolver;
+
+    @Before
+    public void setUp() throws Exception {
+        suggestionHandler = Mockito.spy(new ProductsSuggestionOmniSearchHandler());
+        resolver = Mockito.mock(ResourceResolver.class);
+    }
+
+    @Test
+    public void testGetResults() {
+        OmniSearchHandler productsOmniSearchHandler = Mockito.mock(OmniSearchHandler.class);
+        Whitebox.setInternalState(suggestionHandler, "productsOmniSearchHandler", productsOmniSearchHandler);
+
+        Map<String, Object> params = Collections.singletonMap("fulltext", "whatever");
+        suggestionHandler.getResults(resolver, params, 20, 10);
+
+        // Search is delegated to the legacy Commerce Core ProductsSuggestionOmniSearchHandler
+        Mockito.verify(productsOmniSearchHandler).getResults(resolver, params, 20, 10);
+    }
+
+    @Test
+    public void testSuggestionQuery() throws Exception {
+
+        // The mocked JCR result
+        MockNode jcrNode = new MockNode("/var/commerce/products/jcrnode");
+        jcrNode.setProperty("rep:suggest()", BROOKLYN_COAT);
+        MockQueryResult jcrResults = new MockQueryResult(Collections.singletonList(jcrNode));
+        Query jcrQuery = Mockito.mock(Query.class);
+        Mockito.when(jcrQuery.execute()).thenReturn(jcrResults);
+
+        Mockito.doReturn(jcrQuery).when(suggestionHandler).getSuperSuggestionQuery(resolver, "coats");
+        Mockito.doReturn(resolver).when(suggestionHandler).getResourceResolver();
+
+        ValueFactory valueFactory = Mockito.mock(ValueFactory.class);
+        Mockito.when(valueFactory.createValue(EL_GORDO_DOWN_JACKET)).thenReturn(new MockValue(EL_GORDO_DOWN_JACKET));
+        Session session = Mockito.mock(Session.class);
+        Mockito.when(resolver.adaptTo(Session.class)).thenReturn(session);
+        Mockito.when(session.getValueFactory()).thenReturn(valueFactory);
+
+        // The mocked CIF result
+        MockResource cifProduct = new MockResource(resolver, "/var/commerce/products/graphql/cifresource", "commerce/components/product");
+        cifProduct.addProperty(JcrConstants.JCR_TITLE, EL_GORDO_DOWN_JACKET); // The title is used for the suggestion
+        Mockito.when(resolver.findResources(Mockito.any(), Mockito.any()))
+            .thenReturn(Collections.singletonList((Resource) cifProduct).iterator());
+
+        suggestionHandler.activate(null);
+        Query suggestionQuery = suggestionHandler.getSuggestionQuery(resolver, "coats");
+        QueryResult queryResult = suggestionQuery.execute();
+        RowIterator rows = queryResult.getRows();
+
+        // The CIF result is first, then the JCR result
+        Row row = rows.nextRow();
+        Assert.assertEquals(EL_GORDO_DOWN_JACKET, row.getValue("rep:suggest()").getString());
+        Assert.assertEquals(BROOKLYN_COAT, rows.nextRow().getValue("rep:suggest()").getString());
+
+        // Not implemented
+        Assert.assertNull(suggestionQuery.getLanguage());
+        Assert.assertNull(suggestionQuery.getStatement());
+        Assert.assertNull(suggestionQuery.getStoredQueryPath());
+        Assert.assertNull(suggestionQuery.getBindVariableNames());
+        Assert.assertNull(suggestionQuery.storeAsNode("whatever"));
+
+        Assert.assertNull(queryResult.getColumnNames());
+        Assert.assertNull(queryResult.getNodes());
+        Assert.assertNull(queryResult.getSelectorNames());
+
+        Assert.assertNull(row.getValues());
+        Assert.assertNull(row.getPath());
+        Assert.assertNull(row.getPath("whatever"));
+        Assert.assertNull(row.getNode());
+        Assert.assertNull(row.getNode("whatever"));
+        Assert.assertEquals(0d, row.getScore(), 0);
+        Assert.assertEquals(0d, row.getScore("whatever"), 0);
+    }
+
+    @Test
+    public void testSuggestionQueryNoCifResults() throws Exception {
+
+        // The mocked JCR result
+        MockNode jcrNode = new MockNode("/var/commerce/products/jcrnode");
+        jcrNode.setProperty("rep:suggest()", BROOKLYN_COAT);
+        MockQueryResult jcrResults = new MockQueryResult(Collections.singletonList(jcrNode));
+        Query jcrQuery = Mockito.mock(Query.class);
+        Mockito.when(jcrQuery.execute()).thenReturn(jcrResults);
+
+        Mockito.doReturn(jcrQuery).when(suggestionHandler).getSuperSuggestionQuery(resolver, "coats");
+        Mockito.doReturn(resolver).when(suggestionHandler).getResourceResolver();
+
+        Mockito.when(resolver.findResources(Mockito.any(), Mockito.any())).thenReturn(Collections.emptyListIterator());
+
+        suggestionHandler.activate(null);
+        Query suggestionQuery = suggestionHandler.getSuggestionQuery(resolver, "coats");
+        QueryResult queryResult = suggestionQuery.execute();
+        RowIterator rows = queryResult.getRows();
+
+        // No CIF result, only JCR result
+        Assert.assertEquals(BROOKLYN_COAT, rows.nextRow().getValue("rep:suggest()").getString());
+        Assert.assertFalse(rows.hasNext());
+    }
+}

--- a/bundles/cif-connector-graphql/src/test/resources/simplelogger.properties
+++ b/bundles/cif-connector-graphql/src/test/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+# See https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html for the syntax of this file
+
+# Disable logger during tests
+org.slf4j.simpleLogger.log.com.adobe.cq.commerce.omnisearch.ProductsSuggestionOmniSearchHandler=off
+org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.resource.ResourceMapper=off
+org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl=off
+org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.resource.GraphqlResourceProviderFactory=off

--- a/content/cif-connector/src/main/content/META-INF/vault/filter.xml
+++ b/content/cif-connector/src/main/content/META-INF/vault/filter.xml
@@ -17,6 +17,10 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
 <workspaceFilter version="1.0">
+    <filter root="/libs/commerce/config">
+        <include pattern="/libs/commerce/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-cif-omnisearch"/>
+    </filter>
+
     <filter root="/libs/cif"/>
     <filter root="/libs/commerce/gui/components/common/cifproductfield"/>
     <filter root="/libs/commerce/gui/components/common/cifcategoryfield"/>

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-cif-omnisearch.xml
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-cif-omnisearch.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OsgiConfig"
+          user.default=""
+          user.mapping="[com.adobe.commerce.cif.connector-graphql:omnisearch-service=omnisearch-service]"/>


### PR DESCRIPTION
- implemented an omnisearch handler that supports CIF suggestions

## Motivation and Context

This PR adds support for CIF products suggestions to the products omnisearch. We basically replace the legacy `product` omnisearch handler from Commerce Core, still use it to perform the usual search, and add support for CIF suggestions.

## How Has This Been Tested?

Added unit and integration tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
