### PR TITLE
CIF-971 - Update AEM connector to use GraphQL caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For simplicity, we only provide the version requirements of the `all` package. I
 
 | CIF Connector All   | AEM 6.4 | AEM 6.5 | Magento | Java |
 |---------------------|---------|---------|---------|------|
+| 0.3.1-SNAPSHOT      | 6.4.4.0 | 6.5.0   | 2.3.2   | 1.8  |
 | 0.3.0               | 6.4.4.0 | 6.5.0   | 2.3.1 & 2.3.2   | 1.8  |
 | 0.2.0               | 6.4.4.0 | 6.5.0   | 2.3.1   | 1.8  |
 | 0.1.0               | 6.4.4.0 | 6.5.0   | 2.3.1   | 1.8  |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ For simplicity, we only provide the version requirements of the `all` package. I
 
 | CIF Connector All   | AEM 6.4 | AEM 6.5 | Magento | Java |
 |---------------------|---------|---------|---------|------|
-| 0.3.1-SNAPSHOT      | 6.4.4.0 | 6.5.0   | 2.3.2   | 1.8  |
 | 0.3.0               | 6.4.4.0 | 6.5.0   | 2.3.1 & 2.3.2   | 1.8  |
 | 0.2.0               | 6.4.4.0 | 6.5.0   | 2.3.1   | 1.8  |
 | 0.1.0               | 6.4.4.0 | 6.5.0   | 2.3.1   | 1.8  |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The CIF Magento GraphQL AEM commerce connector has to be configured to access yo
     * Look for `CIF GraphQL Client Configuration Factory`
     * Create a child configuration
         * Keep the `default` service identifier or set something custom. Make sure to use the same value in step 2) below.
-        * For _GraphQL Service URL_ enter the URL of your Magento GraphQL endpoint (usually `https://hostname/graphql`)
+        * For `GraphQL Service URL` enter the URL of your Magento GraphQL endpoint (usually `https://hostname/graphql`)
+        * With `Default HTTP method` you can define whether the underlying HTTP client will send GET or POST requests. Starting with version 2.3.2, Magento supports and can cache some GraphQL queries when using GET.
 
 2) Configuration of the connector
     * Go to http://localhost:4502/system/console/configMgr

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>graphql-client</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/cif-connector-graphql/pom.xml
+++ b/bundles/cif-connector-graphql/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>com.adobe.commerce.cif</groupId>
             <artifactId>graphql-client</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceImpl.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceImpl.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
-import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.adobe.cq.commerce.graphql.client.RequestOptions;
 import com.adobe.cq.commerce.graphql.resource.Constants;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
@@ -67,7 +66,7 @@ public class GraphqlDataServiceImpl implements GraphqlDataService {
 
     // We cannot extend GraphqlClientImpl because it's not OSGi-exported so we use "object composition"
     protected GraphqlClient baseClient;
-    private RequestOptions requestOptions;
+    protected RequestOptions requestOptions;
     private GraphqlDataServiceConfiguration configuration;
 
     // We maintain some caches to speed up all lookups
@@ -118,7 +117,7 @@ public class GraphqlDataServiceImpl implements GraphqlDataService {
                 .build(CacheLoader.from(id -> getCategoryProductsImpl(id)));
         }
 
-        requestOptions = new RequestOptions().withGson(QueryDeserializer.getGson()).withHttpMethod(HttpMethod.GET);
+        requestOptions = new RequestOptions().withGson(QueryDeserializer.getGson());
         if (!GraphqlDataServiceConfiguration.STORE_CODE_DEFAULT.equals(configuration.storeCode())) {
             Header storeHeader = new BasicHeader(Constants.STORE_HEADER, configuration.storeCode());
             requestOptions.withHeaders(Collections.singletonList(storeHeader));

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceImpl.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceImpl.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.adobe.cq.commerce.graphql.client.RequestOptions;
 import com.adobe.cq.commerce.graphql.resource.Constants;
 import com.adobe.cq.commerce.magento.graphql.CategoryTree;
@@ -117,7 +118,7 @@ public class GraphqlDataServiceImpl implements GraphqlDataService {
                 .build(CacheLoader.from(id -> getCategoryProductsImpl(id)));
         }
 
-        requestOptions = new RequestOptions().withGson(QueryDeserializer.getGson());
+        requestOptions = new RequestOptions().withGson(QueryDeserializer.getGson()).withHttpMethod(HttpMethod.GET);
         if (!GraphqlDataServiceConfiguration.STORE_CODE_DEFAULT.equals(configuration.storeCode())) {
             Header storeHeader = new BasicHeader(Constants.STORE_HEADER, configuration.storeCode());
             requestOptions.withHeaders(Collections.singletonList(storeHeader));

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -43,6 +43,7 @@ import com.adobe.cq.commerce.api.CommerceConstants;
 import com.adobe.cq.commerce.api.CommerceException;
 import com.adobe.cq.commerce.api.Product;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
+import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl;
 import com.adobe.cq.commerce.graphql.core.MagentoProduct;
 import com.adobe.cq.commerce.graphql.magento.GraphqlDataServiceConfiguration;
@@ -105,6 +106,7 @@ public class GraphqlResourceProviderTest {
         GraphqlClient baseClient = new GraphqlClientImpl();
         Whitebox.setInternalState(baseClient, "gson", new Gson());
         Whitebox.setInternalState(baseClient, "client", httpClient);
+        Whitebox.setInternalState(baseClient, "httpMethod", HttpMethod.POST);
 
         GraphqlDataServiceConfiguration config = new MockGraphqlDataServiceConfiguration();
         dataService = new GraphqlDataServiceImpl();

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/testing/Utils.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/testing/Utils.java
@@ -16,6 +16,8 @@ package com.adobe.cq.commerce.graphql.testing;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -48,17 +50,32 @@ public class Utils {
 
         @Override
         public boolean matches(Object obj) {
-            if (!(obj instanceof HttpUriRequest) && !(obj instanceof HttpEntityEnclosingRequest)) {
+            if (!(obj instanceof HttpUriRequest)) {
                 return false;
             }
-            HttpEntityEnclosingRequest req = (HttpEntityEnclosingRequest) obj;
-            try {
-                String body = IOUtils.toString(req.getEntity().getContent(), StandardCharsets.UTF_8);
-                Gson gson = new Gson();
-                GraphqlRequest graphqlRequest = gson.fromJson(body, GraphqlRequest.class);
-                return graphqlRequest.getQuery().startsWith(startsWith);
-            } catch (Exception e) {
-                return false;
+
+            if (obj instanceof HttpEntityEnclosingRequest) {
+                // GraphQL query is in POST body
+                HttpEntityEnclosingRequest req = (HttpEntityEnclosingRequest) obj;
+                try {
+                    String body = IOUtils.toString(req.getEntity().getContent(), StandardCharsets.UTF_8);
+                    Gson gson = new Gson();
+                    GraphqlRequest graphqlRequest = gson.fromJson(body, GraphqlRequest.class);
+                    return graphqlRequest.getQuery().startsWith(startsWith);
+                } catch (Exception e) {
+                    return false;
+                }
+            } else {
+                // GraphQL query is in the URL 'query' parameter
+                HttpUriRequest req = (HttpUriRequest) obj;
+                String uri = null;
+                try {
+                    uri = URLDecoder.decode(req.getURI().toString(), StandardCharsets.UTF_8.name());
+                } catch (UnsupportedEncodingException e) {
+                    return false;
+                }
+                String graphqlQuery = uri.substring(uri.indexOf("?query=") + 7);
+                return graphqlQuery.startsWith(startsWith);
             }
         }
 
@@ -77,21 +94,17 @@ public class Utils {
 
         @Override
         public boolean matches(Object obj) {
-            if (!(obj instanceof HttpUriRequest) && !(obj instanceof HttpEntityEnclosingRequest)) {
+            if (!(obj instanceof HttpUriRequest)) {
                 return false;
             }
-            HttpEntityEnclosingRequest req = (HttpEntityEnclosingRequest) obj;
-            try {
-                for (Header header : headers) {
-                    Header reqHeader = req.getFirstHeader(header.getName());
-                    if (reqHeader == null || !reqHeader.getValue().equals(header.getValue())) {
-                        return false;
-                    }
+            HttpUriRequest req = (HttpUriRequest) obj;
+            for (Header header : headers) {
+                Header reqHeader = req.getFirstHeader(header.getName());
+                if (reqHeader == null || !reqHeader.getValue().equals(header.getValue())) {
+                    return false;
                 }
-                return true;
-            } catch (Exception e) {
-                return false;
             }
+            return true;
         }
     }
 

--- a/it/content/src/main/content/jcr_root/apps/cloudcommerce/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl-default.config
+++ b/it/content/src/main/content/jcr_root/apps/cloudcommerce/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl-default.config
@@ -1,4 +1,5 @@
 identifier="default"
 url="https://localhost/graphql"
+httpMethod="POST"
 acceptSelfSignedCertificates="true"
 maxHttpConnections="20"

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/CommerceTestBase.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/CommerceTestBase.java
@@ -89,6 +89,7 @@ public class CommerceTestBase {
         // This configures the lower-level GraphQL client. The Magento client is configured in the test-content package.
         graphqlOsgiConfig.withIdentifier("default")
             .withUrl("https://localhost:" + httpsPort + "/graphql")
+            .withHttpMethod("POST")
             .withAcceptSelfSignedCertificates(true)
             .withCatalogCachingSchedulerEnabled(false);
 
@@ -190,16 +191,21 @@ public class CommerceTestBase {
      * @return
      */
     protected String getValue(Element e) {
-        if (e.tagName().equals("meta"))
+        if (e.tagName().equals("meta")) {
             return e.attr("content");
-        if (e.tagName().equals("a"))
+        }
+        if (e.tagName().equals("a")) {
             return e.attr("href");
-        if (e.tagName().equals("link"))
+        }
+        if (e.tagName().equals("link")) {
             return e.attr("href");
-        if (e.tagName().equals("img"))
+        }
+        if (e.tagName().equals("img")) {
             return e.attr("src");
-        if (e.tagName().equals("input"))
+        }
+        if (e.tagName().equals("input")) {
             return e.attr("value");
+        }
         return e.text();
     }
 

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/GraphqlOSGiConfig.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/GraphqlOSGiConfig.java
@@ -42,6 +42,11 @@ public class GraphqlOSGiConfig {
         return this;
     }
 
+    public GraphqlOSGiConfig withHttpMethod(String httpMethod) {
+        config.put("httpMethod", httpMethod);
+        return this;
+    }
+
     public GraphqlOSGiConfig withAcceptSelfSignedCertificates(boolean acceptSelfSignedCertificates) {
         config.put("acceptSelfSignedCertificates", Boolean.valueOf(acceptSelfSignedCertificates).toString());
         return this;


### PR DESCRIPTION
- this PR updates the GraphQL client dependency in order to support the caching of Magento GraphQL requests. I added a unit test to make sure that a GET request would work as expected and updated the configuration of the integration tests.
- I left the integration tests HTTP method to POST because changing this would require a lot of changes to the mock server but it doesn't bring any real value. Using GET is tested by unit tests also in the GraphQL client library itself.

## Motivation and Context

To support Magento caching, the connector will use GET requests.

## How Has This Been Tested?

Updated unit test, integration tests should simply still work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
