### PR TITLE
CIF-858 - Support Magento multi store bindings in AEM product console

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ The CIF Magento GraphQL AEM commerce connector has to be configured to access yo
     * Look for `CIF Catalog Magento GraphQL Configuration Factory`
     * Create a child configuration
         * For `Magento GraphQL Service Identifier` enter the ID of the GraphQL client you already configured (see "pre-requisites")
-        * For `Magento root category id` enter the ID of the default root category of your Magento instance
-        * For `Magento store view` enter the code of the Magento store view you want to use or keep "default"
 
 3) Binding of product catalog to AEM resource tree
     * Go to AEM Commerce product console (http://localhost:4502/aem/products.html/var/commerce/products)
     * Click on Create > Bind Products
     * Enter Title, unique name and select `magento-graphql` as commerce provider
-    * For "Project", you can select the ID of the Magento instance you created in the previous step
+    * For `Magento store view` enter the code of the Magento store view you want to use or keep "default"
+    * For `Root category id` enter the ID of the Magento root category you want to define as the root of that binding
+    * For `Project`, you can select the ID of the connector instance you created in the previous step
 
 4) AEM content editor product drag & drop
     * To allow authors to drag & drop product assets from the AEM Assets Browser to a page a project specific configuration is needed to configure which component is used when dragging a product to a page. See AEM documentation about [Configuring a Paragraph System so that Dragging an Asset Creates a Component Instance](https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/developing-components.html#ConfiguringaParagraphSystemsothatDragginganAssetCreatesaComponentInstance) for details.

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataService.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataService.java
@@ -27,10 +27,11 @@ public interface GraphqlDataService {
      * Fetches a product by sku.
      * 
      * @param sku The product SKU.
+     * @param storeView An optional Magento store view, can be null.
      * @return The Magento GraphQL product or null if the product is not found.
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
-    public ProductInterface getProductBySku(String sku);
+    public ProductInterface getProductBySku(String sku, String storeView);
 
     /**
      * Performs a full-text search and returns the matching products.
@@ -38,28 +39,31 @@ public interface GraphqlDataService {
      * @param text The full-text search.
      * @param currentPage Specifies which page of results to return. The default value is 1.
      * @param pageSize Specifies the maximum number of results to return at once. This attribute is optional.
+     * @param storeView An optional Magento store view, can be null.
      * @return The list of matching products or an empty list if the search doesn't match any product.
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
-    public List<ProductInterface> searchProducts(String text, Integer currentPage, Integer pageSize);
+    public List<ProductInterface> searchProducts(String text, Integer currentPage, Integer pageSize, String storeView);
 
     /**
      * Returns the Magento category tree for the given category id.
      * 
      * @param categoryId The category id.
+     * @param storeView An optional Magento store view, can be null.
      * @return The category tree starting at the given category.
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
-    public CategoryTree getCategoryTree(Integer categoryId);
+    public CategoryTree getCategoryTree(Integer categoryId, String storeView);
 
     /**
      * Returns the products of the given category id.
      * 
      * @param categoryId The category id.
+     * @param storeView An optional Magento store view, can be null.
      * @return The list of products for this category.
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
-    public List<ProductInterface> getCategoryProducts(Integer categoryId);
+    public List<ProductInterface> getCategoryProducts(Integer categoryId, String storeView);
 
     /**
      * Returns the OSGi configuration of that GraphQL client.
@@ -67,5 +71,4 @@ public interface GraphqlDataService {
      * @return The OSGi configuration of this instance.
      */
     public GraphqlDataServiceConfiguration getConfiguration();
-
 }

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceConfiguration.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceConfiguration.java
@@ -23,7 +23,6 @@ public @interface GraphqlDataServiceConfiguration {
 
     public String CQ_CATALOG_IDENTIFIER = "cq:catalogIdentifier";
     public String CONNECTOR_ID_DEFAULT = "default";
-    public String STORE_CODE_DEFAULT = "default";
 
     public static final int MAX_HTTP_CONNECTIONS_DEFAULT = 20;
     public static final boolean ACCEPT_SELF_SIGNED_CERTIFICATES = false;
@@ -47,19 +46,6 @@ public @interface GraphqlDataServiceConfiguration {
         type = AttributeType.STRING,
         required = true)
     String identifier() default CONNECTOR_ID_DEFAULT;
-
-    @AttributeDefinition(
-        name = "Magento root category id",
-        description = "The ID of the root category.",
-        type = AttributeType.INTEGER,
-        required = true)
-    int rootCategoryId();
-
-    @AttributeDefinition(
-        name = "Magento store view",
-        description = "The code of the Magento store view.",
-        type = AttributeType.STRING)
-    String storeCode() default STORE_CODE_DEFAULT;
 
     @AttributeDefinition(
         name = "Enable/disable product data caching",

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/Constants.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/Constants.java
@@ -26,4 +26,6 @@ public class Constants {
     public static final String CIF_ID = "cifId";
     public static final String PRODUCT_FORMATTED_PRICE = "formattedPrice";
     public static final String STORE_HEADER = "Store";
+    public static final String MAGENTO_STORE_PROPERTY = "cq:magentoStore";
+    public static final String MAGENTO_ROOT_CATEGORY_ID_PROPERTY = "magentoRootCategoryId";
 }

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlQueryLanguageProvider.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlQueryLanguageProvider.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.commerce.graphql.magento.GraphqlDataService;
 import com.adobe.cq.commerce.magento.graphql.CategoryInterface;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
+import com.day.cq.commons.inherit.InheritanceValueMap;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -51,11 +52,16 @@ class GraphqlQueryLanguageProvider<T> implements QueryLanguageProvider<T> {
     private ResourceMapper<T> resourceMapper;
     private GraphqlDataService graphqlDataService;
     private ObjectMapper jsonMapper;
+    private String storeView;
 
-    GraphqlQueryLanguageProvider(ResourceMapper<T> resourceMapper, GraphqlDataService graphqlDataService) {
+    GraphqlQueryLanguageProvider(ResourceMapper<T> resourceMapper, GraphqlDataService graphqlDataService, InheritanceValueMap properties) {
         this.resourceMapper = resourceMapper;
         this.graphqlDataService = graphqlDataService;
         jsonMapper = new ObjectMapper();
+
+        if (properties != null) {
+            storeView = properties.getInherited(Constants.MAGENTO_STORE_PROPERTY, String.class);
+        }
     }
 
     @Override
@@ -82,7 +88,8 @@ class GraphqlQueryLanguageProvider<T> implements QueryLanguageProvider<T> {
         // Convert offset and limit to Magento page number and size
         Pair<Integer, Integer> pagination = toMagentoPageNumberAndSize(offset, limit);
 
-        List<ProductInterface> products = graphqlDataService.searchProducts(fulltext, pagination.getLeft(), pagination.getRight());
+        List<ProductInterface> products = graphqlDataService.searchProducts(fulltext, pagination.getLeft(), pagination.getRight(),
+            storeView);
 
         // The Magento page might start before 'offset' and be bigger than 'limit', so we extract exactly what we need
         int start = offset - ((pagination.getLeft() - 1) * pagination.getRight());

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProvider.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProvider.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.api.CommerceConstants;
 import com.adobe.cq.commerce.graphql.magento.GraphqlDataService;
+import com.day.cq.commons.inherit.InheritanceValueMap;
 import com.day.cq.commons.jcr.JcrConstants;
 
 import static com.adobe.cq.commerce.graphql.resource.Constants.CATEGORY;
@@ -42,11 +43,11 @@ class GraphqlResourceProvider<T> extends ResourceProvider<T> {
     private ResourceMapper<T> resourceMapper;
     private GraphqlQueryLanguageProvider<T> queryLanguageProvider;
 
-    GraphqlResourceProvider(String root, GraphqlDataService graphqlDataService, Scheduler scheduler) {
+    GraphqlResourceProvider(String root, GraphqlDataService graphqlDataService, Scheduler scheduler, InheritanceValueMap properties) {
         this.root = root;
-        rootCategoryId = graphqlDataService.getConfiguration().rootCategoryId();
-        resourceMapper = new ResourceMapper<T>(root, graphqlDataService, scheduler);
-        queryLanguageProvider = new GraphqlQueryLanguageProvider<T>(resourceMapper, graphqlDataService);
+        rootCategoryId = Integer.valueOf(properties.getInherited("magentoRootCategoryId", String.class));
+        resourceMapper = new ResourceMapper<T>(root, graphqlDataService, scheduler, properties);
+        queryLanguageProvider = new GraphqlQueryLanguageProvider<T>(resourceMapper, graphqlDataService, properties);
     }
 
     @Override

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderFactory.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderFactory.java
@@ -99,7 +99,7 @@ public class GraphqlResourceProviderFactory<T> implements CatalogDataResourcePro
             return null;
         }
 
-        ResourceProvider<T> resourceProvider = new GraphqlResourceProvider<T>(root.getPath(), client, scheduler);
+        ResourceProvider<T> resourceProvider = new GraphqlResourceProvider<T>(root.getPath(), client, scheduler, properties);
         return resourceProvider;
     }
 

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/magento/GraphqlAemContext.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/magento/GraphqlAemContext.java
@@ -25,11 +25,11 @@ public final class GraphqlAemContext {
 
     private GraphqlAemContext() {}
 
-    public static AemContext createContext(String contentPath) {
+    public static AemContext createContext(String contentPath, String destPath) {
         return new AemContext(
             (AemContextCallback) context -> {
                 // Load page structure
-                context.load().json(contentPath, "/content");
+                context.load().json(contentPath, destPath);
             },
             ResourceResolverType.JCR_MOCK);
     }

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/magento/MockGraphqlDataServiceConfiguration.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/magento/MockGraphqlDataServiceConfiguration.java
@@ -20,21 +20,9 @@ public class MockGraphqlDataServiceConfiguration implements Annotation, GraphqlD
 
     public static final int ROOT_CATEGORY_ID = 4;
 
-    private String storeCode;
-
     @Override
     public String identifier() {
         return GraphqlDataServiceConfiguration.CONNECTOR_ID_DEFAULT;
-    }
-
-    @Override
-    public int rootCategoryId() {
-        return ROOT_CATEGORY_ID;
-    }
-
-    @Override
-    public String storeCode() {
-        return storeCode != null ? storeCode : GraphqlDataServiceConfiguration.STORE_CODE_DEFAULT;
     }
 
     @Override
@@ -75,9 +63,5 @@ public class MockGraphqlDataServiceConfiguration implements Annotation, GraphqlD
     @Override
     public Class<? extends Annotation> annotationType() {
         return GraphqlDataServiceConfiguration.class;
-    }
-
-    void setStoreCode(String storeCode) {
-        this.storeCode = storeCode;
     }
 }

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlQueryLanguageProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlQueryLanguageProviderTest.java
@@ -42,6 +42,8 @@ import com.google.gson.reflect.TypeToken;
 import static com.adobe.cq.commerce.graphql.resource.GraphqlQueryLanguageProvider.VIRTUAL_PRODUCT_QUERY_LANGUAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class GraphqlQueryLanguageProviderTest {
@@ -56,7 +58,7 @@ public class GraphqlQueryLanguageProviderTest {
         resourceMapper = Mockito.mock(ResourceMapper.class);
         graphqlDataService = Mockito.mock(GraphqlDataService.class);
         ctx = Mockito.mock(ResolveContext.class);
-        queryLanguageProvider = new GraphqlQueryLanguageProvider<>(resourceMapper, graphqlDataService);
+        queryLanguageProvider = new GraphqlQueryLanguageProvider<>(resourceMapper, graphqlDataService, null);
     }
 
     @Test
@@ -64,11 +66,11 @@ public class GraphqlQueryLanguageProviderTest {
         // The search request coming from com.adobe.cq.commerce.impl.omnisearch.ProductsOmniSearchHandler is serialized in JSON
         String jsonRequest = getResource("commerce-products-omni-search-request.json");
 
-        Mockito.when(graphqlDataService.searchProducts(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Collections.emptyList());
+        Mockito.when(graphqlDataService.searchProducts(any(), any(), any(), any())).thenReturn(Collections.emptyList());
         queryLanguageProvider.findResources(ctx, jsonRequest, VIRTUAL_PRODUCT_QUERY_LANGUAGE);
 
         // mock query has limit = 20 and offset = 20 --> so we expect page 2 and size 20
-        Mockito.verify(graphqlDataService, Mockito.times(1)).searchProducts("gloves", Integer.valueOf(2), Integer.valueOf(20));
+        Mockito.verify(graphqlDataService).searchProducts(eq("gloves"), eq(2), eq(20), any());
 
         assertNull(queryLanguageProvider.findResources(ctx, jsonRequest, "whatever"));
     }
@@ -83,11 +85,11 @@ public class GraphqlQueryLanguageProviderTest {
         GraphqlResponse<Query, Error> response = QueryDeserializer.getGson().fromJson(json, type);
         List<ProductInterface> products = response.getData().getProducts().getItems();
 
-        Mockito.when(graphqlDataService.searchProducts(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(products);
+        Mockito.when(graphqlDataService.searchProducts(any(), any(), any(), any())).thenReturn(products);
         Iterator<Resource> it = queryLanguageProvider.findResources(ctx, jsonRequest, VIRTUAL_PRODUCT_QUERY_LANGUAGE);
 
         // The mock query has limit = 2 and offset = 4 --> so we expect page 3 and size 2
-        Mockito.verify(graphqlDataService, Mockito.times(1)).searchProducts("gloves", Integer.valueOf(3), Integer.valueOf(2));
+        Mockito.verify(graphqlDataService).searchProducts(eq("gloves"), eq(3), eq(2), any());
 
         // The JSON response contains 3 products but the query requested 2 products
         assertEquals(2, Iterators.size(it));
@@ -103,11 +105,11 @@ public class GraphqlQueryLanguageProviderTest {
         GraphqlResponse<Query, Error> response = QueryDeserializer.getGson().fromJson(json, type);
         List<ProductInterface> products = response.getData().getProducts().getItems();
 
-        Mockito.when(graphqlDataService.searchProducts(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(products);
+        Mockito.when(graphqlDataService.searchProducts(any(), any(), any(), any())).thenReturn(products);
         Iterator<Resource> it = queryLanguageProvider.findResources(ctx, jsonRequest, VIRTUAL_PRODUCT_QUERY_LANGUAGE);
 
         // No limit and offset in query --> so we expect page 1 and size 20
-        Mockito.verify(graphqlDataService, Mockito.times(1)).searchProducts("gloves", Integer.valueOf(1), Integer.valueOf(20));
+        Mockito.verify(graphqlDataService).searchProducts(eq("gloves"), eq(1), eq(20), any());
 
         // The JSON response contains 3 products and the query requested 20 products
         assertEquals(3, Iterators.size(it));

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderFactoryTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderFactoryTest.java
@@ -30,7 +30,7 @@ import io.wcm.testing.mock.aem.junit.AemContext;
 public class GraphqlResourceProviderFactoryTest {
 
     @Rule
-    public final AemContext context = GraphqlAemContext.createContext("/context/graphql-client-adapter-factory-context.json");
+    public final AemContext context = GraphqlAemContext.createContext("/context/graphql-client-adapter-factory-context.json", "/content");
 
     private GraphqlResourceProviderFactory<?> factory;
     private GraphqlDataServiceImpl client;

--- a/bundles/cif-connector-graphql/src/test/resources/context/graphql-client-adapter-factory-context.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/graphql-client-adapter-factory-context.json
@@ -3,14 +3,18 @@
     "jcr:primaryType": "cq:Page",
     "jcr:content": {
       "jcr:primaryType":"cq:PageContent",
-      "cq:catalogIdentifier": "my-catalog"
+      "cq:catalogIdentifier": "my-catalog",
+      "cq:magentoStore": "default",
+      "magentoRootCategoryId": "4"
     }
   },
   "pageB": {
     "jcr:primaryType": "cq:Page",
     "jcr:content": {
       "jcr:primaryType":"cq:PageContent",
-      "cq:catalogIdentifier": "my-catalog"
+      "cq:catalogIdentifier": "my-catalog",
+      "cq:magentoStore": "default",
+      "magentoRootCategoryId": "4"
     },
     "pageC": {
       "jcr:primaryType": "cq:Page",

--- a/bundles/cif-connector-graphql/src/test/resources/context/graphql-resource-provider-context.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/graphql-resource-provider-context.json
@@ -1,0 +1,15 @@
+{
+  "commerce": {
+    "jcr:primaryType": "sling:Folder",
+    "products": {
+      "jcr:primaryType": "sling:Folder",
+      "magento-graphql": {
+        "jcr:primaryType": "sling:Folder",
+        "cq:catalogDataResourceProviderFactory": "magento-graphql",
+        "cq:catalogIdentifier": "default",
+        "cq:magentoStore": "default",
+        "magentoRootCategoryId": "4"
+      }
+    }
+  }
+}

--- a/content/cif-connector/src/main/content/META-INF/vault/filter.xml
+++ b/content/cif-connector/src/main/content/META-INF/vault/filter.xml
@@ -29,4 +29,6 @@
 
     <!-- remove default config for products search in editor -->
     <filter root="/libs/settings/cq/search/facets/products" />
+    
+    <filter root="/apps/commerce/gui/content/products/bindproducttreewizard/customfields/magento-graphql" mode="update"/>
 </workspaceFilter>

--- a/content/cif-connector/src/main/content/jcr_root/apps/commerce/gui/content/products/bindproducttreewizard/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/apps/commerce/gui/content/products/bindproducttreewizard/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="nt:unstructured"
+        jcr:title="AEM Products | Bind Products"
+        sling:resourceType="granite/ui/components/coral/foundation/page"/>
+    <customfields/>
+</jcr:root>

--- a/content/cif-connector/src/main/content/jcr_root/apps/commerce/gui/content/products/bindproducttreewizard/customfields/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/apps/commerce/gui/content/products/bindproducttreewizard/customfields/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/cif-connector/src/main/content/jcr_root/apps/commerce/gui/content/products/bindproducttreewizard/customfields/magento-graphql/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/apps/commerce/gui/content/products/bindproducttreewizard/customfields/magento-graphql/.content.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    sling:resourceType="granite/ui/components/foundation/layouts/well">
+    <items jcr:primaryType="nt:unstructured">
+        <cqMagentoStore
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+            fieldLabel="Magento Store View"
+            name="./cq:magentoStore"
+            renderReadOnly="{Boolean}false"/>
+        <magentoRootCategoryId
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+            fieldLabel="Root category id"
+            name="./magentoRootCategoryId"
+            renderReadOnly="{Boolean}false"/>
+    </items>
+</jcr:root>

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/gui/components/admin/products/bindproducttreewizard/clientlibs/bindproducttreewizard.css
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/gui/components/admin/products/bindproducttreewizard/clientlibs/bindproducttreewizard.css
@@ -1,3 +1,7 @@
 #cq-commerce-products-bindproducttree-catalog-select-data {
     display: none;
 }
+
+.bindproducttreewizard-customfields.hide {
+    display: none;
+}

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/gui/content/products/bindproducttreewizard/.content.xml
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/gui/content/products/bindproducttreewizard/.content.xml
@@ -1,138 +1,139 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
-          xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-          jcr:primaryType="cq:Page">
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
     <jcr:content
-            jcr:primaryType="nt:unstructured"
-            jcr:title="AEM Products | Bind Products"
-            sling:resourceType="granite/ui/components/coral/foundation/page">
+        jcr:primaryType="nt:unstructured"
+        jcr:title="AEM Products | Bind Products"
+        sling:resourceType="granite/ui/components/coral/foundation/page">
         <head jcr:primaryType="nt:unstructured">
             <viewport
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/admin/page/viewport"/>
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/admin/page/viewport"/>
             <meta
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/meta"
-                    content="chrome=1"
-                    name="X-UA-Compatible"/>
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/meta"
+                content="chrome=1"
+                name="X-UA-Compatible"/>
             <favicon
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/page/favicon"/>
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/page/favicon"/>
             <clientlibs
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
-                    categories="[coralui3,granite.ui.coral.foundation,commerce.gui.products.bindproducttreewizard]"/>
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
+                categories="[coralui3,granite.ui.coral.foundation,commerce.gui.products.bindproducttreewizard,cq.authoring.dialog]"/>
         </head>
         <body
-                granite:id="cq-commerce-products-bindproducttree"
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="granite/ui/components/coral/foundation/page/body">
+            granite:id="cq-commerce-products-bindproducttree"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/page/body">
             <items jcr:primaryType="nt:unstructured">
                 <form
-                        granite:class="form"
-                        granite:id="cq-commerce-products-bindproducttree-form"
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="granite/ui/components/coral/foundation/form"
-                        action="${requestPathInfo.suffix}"
-                        foundationForm="{Boolean}true"
-                        maximized="{Boolean}true"
-                        method="post"
-                        novalidate="{Boolean}true"
-                        style="vertical">
+                    granite:class="form"
+                    granite:id="cq-commerce-products-bindproducttree-form"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form"
+                    action="${requestPathInfo.suffix}"
+                    foundationForm="{Boolean}true"
+                    maximized="{Boolean}true"
+                    method="post"
+                    novalidate="{Boolean}true"
+                    style="vertical">
                     <items jcr:primaryType="nt:unstructured">
                         <charset
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
-                                name="_charset_"
-                                value="utf-8"/>
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                            name="_charset_"
+                            value="utf-8"/>
                         <wizard
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Bind Products"
-                                sling:resourceType="granite/ui/components/coral/foundation/wizard"
-                                cancelHref="${empty header.Referer ? granite:concat(&quot;/aem/products.html&quot;, granite:encodeURIPath(requestPathInfo.suffix)) : header.Referer}">
+                            jcr:primaryType="nt:unstructured"
+                            jcr:title="Bind Products"
+                            sling:resourceType="granite/ui/components/coral/foundation/wizard"
+                            cancelHref="${empty header.Referer ? granite:concat(&quot;/aem/products.html&quot;, granite:encodeURIPath(requestPathInfo.suffix)) : header.Referer}">
                             <items jcr:primaryType="nt:unstructured">
                                 <step1
-                                        jcr:primaryType="nt:unstructured"
-                                        jcr:title="Properties"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                                        maximized="{Boolean}true">
+                                    jcr:primaryType="nt:unstructured"
+                                    jcr:title="Properties"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                    maximized="{Boolean}true">
                                     <items jcr:primaryType="nt:unstructured">
                                         <fixedcolumn
-                                                jcr:primaryType="nt:unstructured"
-                                                margin="true"
-                                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                            margin="true">
                                             <items jcr:primaryType="nt:unstructured">
-                                                <column jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                <column
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/container">
                                                     <items jcr:primaryType="nt:unstructured">
                                                         <title
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                fieldLabel="Title"
-                                                                name="./jcr:title"
-                                                                renderReadOnly="{Boolean}false"/>
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            fieldLabel="Title"
+                                                            name="./jcr:title"
+                                                            renderReadOnly="{Boolean}false"/>
                                                         <name
-                                                                granite:id="cq-commerce-products-bindproducttree-name"
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                fieldLabel="Name"
-                                                                name=":name"
-                                                                required="{Boolean}true"/>
+                                                            granite:id="cq-commerce-products-bindproducttree-name"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            fieldLabel="Name"
+                                                            name=":name"
+                                                            required="{Boolean}true"/>
                                                         <commerceprovider
-                                                                granite:id="cq-commerce-products-bindproducttree-provider-select"
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
-                                                                fieldLabel="Commerce provider"
-                                                                name="./cq:catalogDataResourceProviderFactory"
-                                                                required="{Boolean}true"
-                                                                emptyText="Select commerce provider"
-                                                                fieldDescription="The commerce provider. If this list is empty check the configurations of the CIF Connector Configuration Service ">>
+                                                            granite:class="cq-dialog-dropdown-showhide"
+                                                            granite:id="cq-commerce-products-bindproducttree-provider-select"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            emptyText="Select commerce provider"
+                                                            fieldDescription="The commerce provider. If this list is empty check the configurations of the CIF Connector Configuration Service "
+                                                            fieldLabel="Commerce provider"
+                                                            name="./cq:catalogDataResourceProviderFactory"
+                                                            required="{Boolean}true">
                                                             <datasource
-                                                                    jcr:primaryType="nt:unstructured"
-                                                                    sling:resourceType="commerce/gui/components/admin/products/bindproducttreewizard/commerceproviderdatasource"/>
-
+                                                                jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="commerce/gui/components/admin/products/bindproducttreewizard/commerceproviderdatasource"/>
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cq-dialog-dropdown-showhide-target=".bindproducttreewizard-customfields"/>
                                                         </commerceprovider>
-
+                                                        <customfields
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="commerce/gui/components/admin/common/includetargets"
+                                                            path="commerce/gui/content/products/bindproducttreewizard/customfields"
+                                                            rel="bindproducttreewizard-customfields"/>
                                                         <catalogidentifier
-                                                                granite:id="cq-commerce-products-bindproducttree-catalog-select"
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
-                                                                fieldLabel="Project"
-                                                                name="./cq:catalogIdentifier"
-                                                                emptyText="Select project"
-                                                                disabled="{Boolean}true">
-                                                        </catalogidentifier>
-
+                                                            granite:id="cq-commerce-products-bindproducttree-catalog-select"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            disabled="{Boolean}true"
+                                                            emptyText="Select project"
+                                                            fieldLabel="Project"
+                                                            name="./cq:catalogIdentifier"/>
                                                         <catalogidentifierdata
-                                                                granite:id="cq-commerce-products-bindproducttree-catalog-select-data"
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
-                                                                required="{Boolean}false"
-                                                                disabled="{Boolean}true">
+                                                            granite:id="cq-commerce-products-bindproducttree-catalog-select-data"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            disabled="{Boolean}true"
+                                                            required="{Boolean}false">
                                                             <datasource
-                                                                    jcr:primaryType="nt:unstructured"
-                                                                    sling:resourceType="commerce/gui/components/admin/products/bindproducttreewizard/catalogidentifierdatasource"/>
-
+                                                                jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="commerce/gui/components/admin/products/bindproducttreewizard/catalogidentifierdatasource"/>
                                                         </catalogidentifierdata>
-                                                        
                                                         <language
-                                                                emptyText="Select"
-                                                                fieldLabel="Language"
-                                                                granite:class="language"
-                                                                jcr:primaryType="nt:unstructured"
-                                                                name="./jcr:language"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/select">
+                                                            granite:class="language"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            emptyText="Select"
+                                                            fieldLabel="Language"
+                                                            name="./jcr:language">
                                                             <datasource
-                                                                    jcr:primaryType="nt:unstructured"
-                                                                    sling:resourceType="cq/gui/components/common/datasources/languages"/>
-                                                        </language>
-
-                                                        <node-type
                                                                 jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
-                                                                name="./jcr:primaryType"
-                                                                value="sling:Folder"/>
+                                                                sling:resourceType="cq/gui/components/common/datasources/languages"/>
+                                                        </language>
+                                                        <node-type
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                                            name="./jcr:primaryType"
+                                                            value="sling:Folder"/>
                                                     </items>
                                                 </column>
                                             </items>
@@ -140,16 +141,16 @@
                                     </items>
                                     <parentConfig jcr:primaryType="nt:unstructured">
                                         <next
-                                                granite:class="foundation-wizard-control"
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/button"
-                                                disabled="{Boolean}true"
-                                                text="Bind"
-                                                type="submit"
-                                                variant="primary">
+                                            granite:class="foundation-wizard-control"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/button"
+                                            disabled="{Boolean}true"
+                                            text="Bind"
+                                            type="submit"
+                                            variant="primary">
                                             <granite:data
-                                                    jcr:primaryType="nt:unstructured"
-                                                    foundation-wizard-control-action="next"/>
+                                                jcr:primaryType="nt:unstructured"
+                                                foundation-wizard-control-action="next"/>
                                         </next>
                                     </parentConfig>
                                 </step1>

--- a/it/content/src/main/content/jcr_root/apps/cloudcommerce/config/com.adobe.cq.commerce.graphql.magento.GraphqlDataServiceImpl-default.config
+++ b/it/content/src/main/content/jcr_root/apps/cloudcommerce/config/com.adobe.cq.commerce.graphql.magento.GraphqlDataServiceImpl-default.config
@@ -1,6 +1,4 @@
 identifier="default"
-rootCategoryId="4"
-storeCode="default"
 productCachingEnabled="true"
 productCachingTimeMinutes="5"
 productCachingSize="1000"

--- a/it/http/src/test/java/com/adobe/cq/commerce/it/http/GraphqlProductConsoleIT.java
+++ b/it/http/src/test/java/com/adobe/cq/commerce/it/http/GraphqlProductConsoleIT.java
@@ -62,6 +62,8 @@ public class GraphqlProductConsoleIT extends CommerceTestBase {
             .addParameter(":name", "graphql")
             .addParameter("./cq:catalogDataResourceProviderFactory", "magento-graphql")
             .addParameter("./cq:catalogIdentifier", "default")
+            .addParameter("./cq:magentoStore", "default")
+            .addParameter("./magentoRootCategoryId", "4")
             .addParameter("./jcr:language", "en_us")
             .addParameter("./jcr:primaryType", "sling:Folder")
             .build();


### PR DESCRIPTION
- removed the store view and toot category id configurations from the OSGi configuration
- added the possibility to add custom configuration options to the "binding products" wizard
- added custom config options to the Magento GraphQL provider
- extended and fixed unit and integration tests

## Description

With this change, a single instance of the connector will support multiple stores and multiple catalog bindings, as this is no longer configured in the OSGi service, but is now configured in the JCR folder of the binding.

## How Has This Been Tested?

Extended unit and integration tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
