### PR TITLE
CIF-993 - Extend SKU selection for product variants in product picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The product picker field supports the following optional properties:
 * `rootPath` - configure the root path of the virtual catalog data tree to be used (default = `/var/commerce/products`)
 * `multiple` (true, false) - allows to select one or multiple products (default = false)
 * `emptyText` - to configure the empty text value of the picker field
-* `selectionId`(id, sku, slug, path) - allows to choose the product attribute to be returned by the picker (default = id)
+* `selectionId` (id, sku, slug, path, skus) - allows to choose the product attribute to be returned by the picker (default = id). Using `sku` returns the sku of the selected product, while using `skus` returns a string like `base#variant` with the skus of the base product and the selected variant, or a single sku if a base product is selected.
+* `filter` (folderOrProduct, folderOrProductOrVariant) - filters the content to be rendered by the picker while navigating the product tree. `folderOrProduct` - renders folders and products. `folderOrProductOrVariant` - renders folders, product and product variants. If a product or product variant is rendered it becomes also selectable in the picker. (default = `folderOrProduct`) 
 
 ### Category Picker
 The category picker (provided by `/libs/commerce/gui/components/common/cifcategoryfield`) can be used in a component dialog as well. The following snippet can be used in a cq:dialog configuration:
@@ -103,7 +104,6 @@ The category picker field supports the following optional properties:
 * `multiple` (true, false) - allows to select one or multiple categories (default = false)
 * `emptyText` - to configure the empty text value of the picker field
 * `selectionId`(id, path, sku, slug) - allows to choose the category attribute to be returned by the picker (default = id)
-* `filter`(folderOrProduct, folderOrProductOrVariant) - filters the content to be rendered by the picker while navigating the product tree. folderOrProduct - renders folders and products. folderOrProductOrVariant - renders folders, product and product variants. If a product or product variant is rendered it becomes also selectable in the picker.  (default = folderOrProduct) 
  
 ## Building and installing from source
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The product picker field supports the following optional properties:
 * `rootPath` - configure the root path of the virtual catalog data tree to be used (default = `/var/commerce/products`)
 * `multiple` (true, false) - allows to select one or multiple products (default = false)
 * `emptyText` - to configure the empty text value of the picker field
-* `selectionId` (id, sku, slug, path, skus) - allows to choose the product attribute to be returned by the picker (default = id). Using `sku` returns the sku of the selected product, while using `skus` returns a string like `base#variant` with the skus of the base product and the selected variant, or a single sku if a base product is selected.
+* `selectionId` (id, sku, slug, path, combinedSku) - allows to choose the product attribute to be returned by the picker (default = id). Using `sku` returns the sku of the selected product, while using `combinedSku` returns a string like `base#variant` with the skus of the base product and the selected variant, or a single sku if a base product is selected.
 * `filter` (folderOrProduct, folderOrProductOrVariant) - filters the content to be rendered by the picker while navigating the product tree. `folderOrProduct` - renders folders and products. `folderOrProductOrVariant` - renders folders, product and product variants. If a product or product variant is rendered it becomes also selectable in the picker. (default = `folderOrProduct`) 
 
 ### Category Picker

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/CIFProductFieldHelper.java
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/CIFProductFieldHelper.java
@@ -27,7 +27,7 @@ public class CIFProductFieldHelper extends WCMUsePojo {
     @Override
     public void activate() throws Exception {
         String st = getRequest().getParameter("selectionId");
-        if ("id".equals(st) || "sku".equals(st) || "path".equals(st) || "slug".equals(st) || "skus".equals(st)) {
+        if ("id".equals(st) || "sku".equals(st) || "path".equals(st) || "slug".equals(st) || "combinedSku".equals(st)) {
             selectionId = st;
         } else {
             selectionId = "id";
@@ -70,7 +70,7 @@ public class CIFProductFieldHelper extends WCMUsePojo {
         if ("sku".equals(selectionId)) {
             return getProperties().get("sku", String.class);
         }
-        if ("skus".equals(selectionId)) {
+        if ("combinedSku".equals(selectionId)) {
             String sku = getProperties().get("sku", String.class);
             if ("variant".equals(getProperties().get("cq:commerceType", String.class))) {
                 Resource parent = getResource().getParent();

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/CIFProductFieldHelper.java
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/CIFProductFieldHelper.java
@@ -27,7 +27,7 @@ public class CIFProductFieldHelper extends WCMUsePojo {
     @Override
     public void activate() throws Exception {
         String st = getRequest().getParameter("selectionId");
-        if ("id".equals(st) || "sku".equals(st) || "path".equals(st) || "slug".equals(st)) {
+        if ("id".equals(st) || "sku".equals(st) || "path".equals(st) || "slug".equals(st) || "skus".equals(st)) {
             selectionId = st;
         } else {
             selectionId = "id";
@@ -69,6 +69,16 @@ public class CIFProductFieldHelper extends WCMUsePojo {
         }
         if ("sku".equals(selectionId)) {
             return getProperties().get("sku", String.class);
+        }
+        if ("skus".equals(selectionId)) {
+            String sku = getProperties().get("sku", String.class);
+            if ("variant".equals(getProperties().get("cq:commerceType", String.class))) {
+                Resource parent = getResource().getParent();
+                String parentSku = parent.getValueMap().get("sku", String.class);
+                return parentSku + "#" + sku;
+            } else {
+                return sku;
+            }
         }
         return getProperties().get("identifier", String.class);
     }

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/Initializer.java
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/Initializer.java
@@ -53,7 +53,7 @@ public class Initializer extends WCMUsePojo {
             defaultEmptyText = "Product SKU";
         } else if ("slug".equals(selectionId)) {
             defaultEmptyText = "Product slug";
-        } else if ("skus".equals(selectionId)) {
+        } else if ("combinedSku".equals(selectionId)) {
             defaultEmptyText = "Product SKU(s) separated by # character";
         } else {
             defaultEmptyText = "Product ID";

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/Initializer.java
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifproductfield/Initializer.java
@@ -53,6 +53,8 @@ public class Initializer extends WCMUsePojo {
             defaultEmptyText = "Product SKU";
         } else if ("slug".equals(selectionId)) {
             defaultEmptyText = "Product slug";
+        } else if ("skus".equals(selectionId)) {
+            defaultEmptyText = "Product SKU(s) separated by # character";
         } else {
             defaultEmptyText = "Product ID";
         }


### PR DESCRIPTION
- added an option to return the "base#variant" skus when selecting a product variant

## Motivation and Context

When selecting a variant, we need an option to return the `base#variant` skus because by default, it's not possible to query a variant product in Magento so we need the base product sku to be able to query the product and its variants, and then access the selected variant.

## How Has This Been Tested?

We don't have unit tests for these java files because they belong to a content package, and do not yet UI tests. I tested everything manually.

## Screenshots (if appropriate):

![Screenshot 2019-07-25 at 12 35 28](https://user-images.githubusercontent.com/24548615/61871711-cce5d600-aee1-11e9-98f4-9925dec57093.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
