### PR TITLE
CIF-652 - CIF Cloud support for viewing product description within Product Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ The project provides a [sample scaffolding](./content/cif-connector/src/main/con
 To see the properties page go to the products console (in Commerce --> Products) and select a cloud product. The `Properties` action should be available and it should open the properties page when clicked.   
  
  
+### Using a scaffolding to display the product properties page
+
+The project provides a [sample scaffolding](./content/cif-connector/src/main/content/jcr_root/apps/commerce/scaffolding/product/.content.xml) that only displays the basic information about a product. To link this scaffolding to your catalog root you have to do the following steps:
+1. Open CRXDe Lite and go to `/apps/commerce/scaffolding/product`
+2. Update the `cq:targetPath` property to point to the root of your catalog
+3. Save the changes
+
+To see the properties page go to the products console (in Commerce --> Products) and select a cloud product. The `Properties` action should be available and it should open the properties page when clicked.   
+ 
+ 
 ## Building and installing from source
 
 ### Pre-requisites

--- a/README.md
+++ b/README.md
@@ -114,17 +114,6 @@ The project provides a [sample scaffolding](./content/cif-connector/src/main/con
 
 To see the properties page go to the products console (in Commerce --> Products) and select a cloud product. The `Properties` action should be available and it should open the properties page when clicked.   
  
- 
-### Using a scaffolding to display the product properties page
-
-The project provides a [sample scaffolding](./content/cif-connector/src/main/content/jcr_root/apps/commerce/scaffolding/product/.content.xml) that only displays the basic information about a product. To link this scaffolding to your catalog root you have to do the following steps:
-1. Open CRXDe Lite and go to `/apps/commerce/scaffolding/product`
-2. Update the `cq:targetPath` property to point to the root of your catalog
-3. Save the changes
-
-To see the properties page go to the products console (in Commerce --> Products) and select a cloud product. The `Properties` action should be available and it should open the properties page when clicked.   
- 
- 
 ## Building and installing from source
 
 ### Pre-requisites

--- a/content/cif-connector/src/main/content/jcr_root/apps/commerce/scaffolding/product/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/apps/commerce/scaffolding/product/.content.xml
@@ -76,8 +76,7 @@
                                                                     fieldLabel="SKU"
                                                                     name="sku"
                                                                     renderReadOnly="{Boolean}true"
-                                                                    required="{Boolean}true"
-                                                                    validation="weretail.sku"/>
+                                                                    required="{Boolean}true"/>
                                                             <price
                                                                     jcr:primaryType="nt:unstructured"
                                                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/content/cif-connector/src/main/content/jcr_root/apps/commerce/scaffolding/product/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/apps/commerce/scaffolding/product/.content.xml
@@ -63,12 +63,13 @@
                                                                 fieldLabel="Title"
                                                                 name="jcr:title"
                                                                 renderReadOnly="{Boolean}true"
-                                                                required="{Boolean}true"/>
+                                                                disabled="{Boolean}true"/>
                                                             <description
                                                                 jcr:primaryType="nt:unstructured"
                                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textarea"
                                                                 fieldLabel="Description"
                                                                 name="jcr:description"
+                                                                disabled="{Boolean}true"
                                                                 renderReadOnly="{Boolean}true"/>
                                                             <sku
                                                                     jcr:primaryType="nt:unstructured"
@@ -76,12 +77,13 @@
                                                                     fieldLabel="SKU"
                                                                     name="sku"
                                                                     renderReadOnly="{Boolean}true"
-                                                                    required="{Boolean}true"/>
+                                                                    disabled="{Boolean}true"/>
                                                             <price
                                                                     jcr:primaryType="nt:unstructured"
                                                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                                     fieldLabel="Price"
                                                                     name="formattedPrice"
+                                                                    disabled="{Boolean}true"
                                                                     renderReadOnly="{Boolean}true"/>
                                                             <charset
                                                                 jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
Add the `disabled` flag to the fields of the scaffolding

## Description

The fields of the scaffolding were marked as "read-only", but they could still be changed (although there wasn't any "save" button). This leads to confusion, so the fields were marked as `disabled`

## Related Issue

CIF-652

## Motivation and Context

Avoid the confusion caused by having updateable fields without any save button.

## How Has This Been Tested?

Functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
