### PR TITLE
CIF-996 - Show the store-related properties in the cloud bound folder…

### DIFF
--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
@@ -325,7 +325,8 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
             while (events.hasNext()) {
                 final Event event = events.nextEvent();
                 final String path = event.getPath();
-                if (event.getType() == Event.NODE_ADDED) {
+                final int eventType = event.getType();
+                if (eventType == Event.NODE_ADDED) {
                     nodeAdded = true;
                     Session session = resolver.adaptTo(Session.class);
                     final Node node = session.getNode(path);
@@ -333,9 +334,14 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
                         node.hasProperty(CatalogDataResourceProviderFactory.PROPERTY_FACTORY_ID)) {
                         actions.put(path, true);
                     }
-                } else if (event.getType() == Event.NODE_REMOVED && providers.containsKey(path)) {
+                } else if (eventType == Event.NODE_REMOVED && providers.containsKey(path)) {
                     nodeRemoved = true;
                     actions.put(path, false);
+                } else if ((eventType == Event.PROPERTY_CHANGED || eventType == Event.PROPERTY_ADDED || eventType == Event.PROPERTY_REMOVED)
+                    && isRegistredPath(path)) {
+                    // force re-registering
+                    nodeAdded = true;
+                    nodeRemoved = true;
                 }
             }
 
@@ -361,6 +367,15 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
         } catch (RepositoryException e) {
             log.error("Unexpected repository exception during event processing.", e);
         }
+    }
+
+    private boolean isRegistredPath(String path) {
+        for (String provider : providers.keySet()) {
+            if (path.startsWith(provider)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Reference(

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImplTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImplTest.java
@@ -148,6 +148,45 @@ public class CatalogDataResourceProviderManagerImplTest extends RepositoryBaseTe
         testBindFactoryCreateRoots2(ROOT_COUNT);
     }
 
+    @Test
+    public void testBindFactoryModifyRoot() throws Exception {
+        manager.activate(componentContext);
+
+        FactoryConfig factoryConfig = bindFactory();
+
+        String rootPath = createDataRoot(factoryConfig.factoryId);
+
+        Thread.sleep(WAIT_FOR_EVENTS);
+
+        Assert.assertEquals(1, getProviders().size());
+        Assert.assertEquals(1, getProviderRegistrations().size());
+        Assert.assertEquals(1, manager.getProviderFactories().values().size());
+        Assert.assertTrue(manager.getProviderFactories().values().contains(factoryConfig.factory));
+
+        Assert.assertTrue(getProviderRegistrations().keySet().iterator().hasNext());
+        Object oldProvider = getProviderRegistrations().keySet().iterator().next();
+        Assert.assertNotNull(oldProvider);
+
+        Assert.assertTrue(session.nodeExists(rootPath));
+        Node root = session.getNode(rootPath);
+        root.setProperty("dummy", "dummy");
+        session.save();
+
+        Thread.sleep(WAIT_FOR_EVENTS);
+
+        Assert.assertEquals(1, getProviders().size());
+        Assert.assertEquals(1, getProviderRegistrations().size());
+        Assert.assertEquals(1, manager.getProviderFactories().values().size());
+        Assert.assertTrue(manager.getProviderFactories().values().contains(factoryConfig.factory));
+
+        Assert.assertTrue(getProviderRegistrations().keySet().iterator().hasNext());
+        Object newPovider = getProviderRegistrations().keySet().iterator().next();
+        Assert.assertNotNull(newPovider);
+
+        // check reregistration: new provider not the same as old provider
+        Assert.assertNotSame(oldProvider, newPovider);
+    }
+
     private void testBindFactoryCreateRemoveRoots(int createCount, int removeCount) throws Exception {
         if (removeCount > createCount) {
             throw new IllegalArgumentException("removeCount above createCount: " + removeCount + " > " + createCount);

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/components/ccifrootfolder/_cq_dialog/.content.xml
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/components/ccifrootfolder/_cq_dialog/.content.xml
@@ -55,6 +55,10 @@
                                             name="./cq:catalogIdentifier"
                                             renderReadOnly="{Boolean}true"
                                             required="{Boolean}false"/>
+                                    <customfields
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="commerce/components/ccifrootfolder/include"
+                                            path="${empty param.item ? requestPathInfo.suffix : param.item}"/>
                                 </items>
                             </properties>
                             <systemprops

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/components/ccifrootfolder/include/include.jsp
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/components/ccifrootfolder/include/include.jsp
@@ -1,0 +1,48 @@
+<%--
+
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+
+--%><%
+%><%@include file="/libs/granite/ui/global.jsp"%><%
+%><%@page session="false"
+          import="org.apache.commons.lang.StringUtils,
+                  com.adobe.granite.ui.components.AttrBuilder,
+                  com.adobe.granite.ui.components.Tag"%><%
+
+    String path = cmp.getExpressionHelper().getString(cmp.getConfig().get("path", String.class));
+    if (path == null) {
+        return;
+    }
+
+    Resource target = resourceResolver.getResource(path);
+    if (target == null) {
+        return;
+    }
+
+    String provider = target.getValueMap().get("cq:catalogDataResourceProviderFactory", String.class);
+    if (StringUtils.isBlank(provider)) {
+        return;
+    }
+
+    Resource customFieldsParent = resourceResolver.getResource("commerce/gui/content/products/bindproducttreewizard/customfields");
+    if (customFieldsParent == null) {
+        return;
+    }
+
+    Resource customFields = customFieldsParent.getChild(provider);
+    if (customFields == null) {
+        return;
+    }
+
+    AttrBuilder attrs = new AttrBuilder(request, xssAPI);
+    Tag tag = new Tag("div", attrs);
+    cmp.include(customFields, customFields.getResourceType(), tag);
+%>


### PR DESCRIPTION

With the multi-store bindings in place we also need to show the store-related properties in the cloud bound folder.

## Description

Include the custom fields of the bindproducttreewizard in the properties page of ccifrootfolder.

## Related Issue

CIF-996

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
