### PR TITLE
CIF-1069 - The search in the product picker always returns the product id

### DIFF
--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/content/common/cifproductfield/picker/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/content/common/cifproductfield/picker/.content.xml
@@ -20,6 +20,13 @@
             jcr:primaryType="nt:unstructured"
             name="fulltext"
             targetCollection="#cq-commerce-product-picker-search-collection">
+        <form jcr:primaryType="nt:unstructured">
+            <selectionid
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                    name="selectionId"
+                    value="${granite:encodeURIComponent(param.selectionId)}"/>
+        </form>
         <views jcr:primaryType="nt:unstructured">
             <card
                     granite:id="cq-commerce-product-picker-search-collection"


### PR DESCRIPTION

Add selectionId parameter to search form.

## Description

The search in the product picker does not consider the selectionId property, and hence always returns the product id.

## Related Issue

CIF-1069

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?


Manually.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
