### PR TITLE
CIF-1082 - Change AEM Connector release to a "reactor" release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,5 @@
 version: 2.1
 
-# This is a reusable command to perform a maven release
-commands:
-  release:
-    description: "Performs a maven release in the specified folder"
-    parameters:
-      folder:
-        type: string
-    steps:
-      - checkout
-      - restore_cache:
-          keys: 
-            - maven-repo-v1-{{ checksum "pom.xml" }}
-            - maven-repo-v1-
-      - run:
-          name: Release
-          # Only performs a 'mvn deploy' after the 'mvn release:prepare' because circleCI
-          # already checks out the git tag like 'mvn release:perform' would do. 
-          command: |
-            echo $GPG_PRIVATE_KEY | base64 --decode | gpg --batch --import
-            cd << parameters.folder >>
-            mvn -B -s /home/circleci/project/.circleci/settings.xml clean deploy -P release-sign-artifacts
-            rm -rf /home/circleci/.gnupg
-
 executors:
   cif_executor:
     docker:
@@ -60,41 +37,23 @@ jobs:
           name: Upload Code Coverage
           command: bash <(curl -s https://codecov.io/bash) -F unittests
           
-  release_cif_connector_parent:
+  release:
     executor: cif_executor
     steps:
-      - release:
-          folder: "parent"
-          
-  release_cif_connector_graphql:
-    executor: cif_executor
-    steps:
-      - release:
-          folder: "bundles/cif-connector-graphql"
-            
-  release_cif_virtual_catalog:
-    executor: cif_executor
-    steps:
-      - release:
-          folder: "bundles/cif-virtual-catalog"
-            
-  release_cif_connector_content:
-    executor: cif_executor
-    steps:
-      - release:
-          folder: "content/cif-connector"
-            
-  release_cif_virtual_catalog_content:
-    executor: cif_executor
-    steps:
-      - release:
-          folder: "content/cif-virtual-catalog"
-            
-  release_cif_connector_all:
-    executor: cif_executor
-    steps:
-      - release:
-          folder: "all"
+      - checkout
+      - restore_cache:
+          keys: 
+            - maven-repo-v1-{{ checksum "pom.xml" }}
+            - maven-repo-v1-
+      - run:
+          name: Release
+          # Only performs a 'mvn deploy' after the 'mvn release:prepare' because circleCI
+          # already checks out the git tag like 'mvn release:perform' would do.
+          # The "skip-it" property ensures that we do not release the integration tests sub-modules
+          command: |
+            echo $GPG_PRIVATE_KEY | base64 --decode | gpg --batch --import
+            mvn -B -s /home/circleci/project/.circleci/settings.xml clean deploy -Prelease-sign-artifacts -Dskip-it
+            rm -rf /home/circleci/.gnupg
 
 workflows:
   version: 2
@@ -105,56 +64,11 @@ workflows:
             tags:
               only: /.*/
               
-      - release_cif_connector_parent:
+      - release:
           requires:
             - build
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /^cif-connector-parent-\d+\.\d+\.\d+$/
-              
-      - release_cif_connector_graphql:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^cif-connector-graphql-\d+\.\d+\.\d+$/
-              
-      - release_cif_virtual_catalog:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^cif-virtual-catalog-\d+\.\d+\.\d+$/
-              
-      - release_cif_connector_content:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^cif-connector-content-\d+\.\d+\.\d+$/
-              
-      - release_cif_virtual_catalog_content:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^cif-virtual-catalog-content-\d+\.\d+\.\d+$/
-              
-      - release_cif_connector_all:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^cif-connector-all-\d+\.\d+\.\d+$/
+              only: /^cif-connector-reactor-\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ mvn clean verify -Ptest-all -Dsling.it.instance.url.1=http://localhost:4502 -Dsl
 
 ## Releases to Maven Central
 
-Releases are triggered by manually running `mvn release:prepare release:clean` on the `master` branch in one of the modules/subprojects of this repository. Once you choose the release and the next snapshot versions, this commits the change along with a release git tag like for example `cif-connector-all-x.y.z`. Note that the commits are not automatically pushed to the git repository, so you have some time to check your changes and then manually push them. The push then triggers a dedicated `CircleCI` build that performs the deployment of the tagged artifact to Maven Central.
+Releases are triggered by manually running `mvn release:prepare release:clean -Dskip-it` on the `master` branch in the **top-level folder** of this repository. Once you choose the release and the next snapshot versions, this commits the change along with a release git tag like for example `cif-connector-reactor-x.y.z`. Note that the commits are not automatically pushed to the git repository, so you have some time to check your changes and then manually push them. The push then triggers a dedicated `CircleCI` build that performs the deployment of all the artifacts to Maven Central.
 
-Important: do **not** trigger releases from the reactor (top-level) project because we release each module independently.
+Note that the `skip-it` property ensures that the integration tests sub-modules are not released.
+
+Important: starting with version `0.6.0`, we changed the release strategy to a "reactor" release when all the artifacts are released with the same version. This makes it easier to perform releases and simplifies versioning.
 
 ### Contributing
  

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -17,13 +17,12 @@
     <parent>
         <groupId>com.adobe.commerce.cif</groupId>
         <artifactId>cif-connector-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.6.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cif-connector-all</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
     <packaging>content-package</packaging>
 
     <name>CIF Connector - All content package</name>
@@ -95,21 +94,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
 
@@ -120,26 +104,26 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cif-connector-graphql</artifactId>
-            <version>0.4.0</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cif-virtual-catalog</artifactId>
-            <version>0.2.0</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cif-connector-content</artifactId>
-            <version>0.2.1</version>
+            <version>${project.version}</version>
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cif-virtual-catalog-content</artifactId>
-            <version>0.3.0</version>
+            <version>${project.version}</version>
             <type>zip</type>
             <scope>provided</scope>
         </dependency>

--- a/bundles/cif-connector-graphql/pom.xml
+++ b/bundles/cif-connector-graphql/pom.xml
@@ -17,13 +17,12 @@
     <parent>
         <groupId>com.adobe.commerce.cif</groupId>
         <artifactId>cif-connector-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.6.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cif-connector-graphql</artifactId>
-    <version>0.4.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     
     <name>CIF Connector - GraphQL Bundle</name>
@@ -96,21 +95,6 @@
                         <exclude>src/test/resources/**/*</exclude>
                     </excludes>
                 </configuration>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             
             <plugin>

--- a/bundles/cif-virtual-catalog/pom.xml
+++ b/bundles/cif-virtual-catalog/pom.xml
@@ -17,13 +17,12 @@
     <parent>
         <groupId>com.adobe.commerce.cif</groupId>
         <artifactId>cif-connector-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.6.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cif-virtual-catalog</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     
     <name>CIF Virtual Catalog - Bundle</name>
@@ -82,21 +81,6 @@
                         <exclude>src/test/resources/*</exclude>
                     </excludes>
                 </configuration>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             
             <plugin>

--- a/content/cif-connector/pom.xml
+++ b/content/cif-connector/pom.xml
@@ -17,13 +17,12 @@
     <parent>
         <groupId>com.adobe.commerce.cif</groupId>
         <artifactId>cif-connector-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.6.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cif-connector-content</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
     <packaging>content-package</packaging>
     
     <name>CIF Connector - Content Package</name>

--- a/content/cif-virtual-catalog/pom.xml
+++ b/content/cif-virtual-catalog/pom.xml
@@ -17,13 +17,12 @@
     <parent>
         <groupId>com.adobe.commerce.cif</groupId>
         <artifactId>cif-connector-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.6.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cif-virtual-catalog-content</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
     <packaging>content-package</packaging>
 
     <name>CIF Virtual Catalog - Content package</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -104,7 +104,7 @@
                     <configuration>
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.adobe.commerce.cif</groupId>
     <artifactId>cif-connector-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.5-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
 
     <name>CIF Connector - Parent project</name>
     <description>Parent project for the CIF connector</description>
@@ -91,7 +91,7 @@
                         <preparationGoals>clean install</preparationGoals>
                         <goals>deploy</goals>
                         <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
-                        <autoVersionSubmodules>false</autoVersionSubmodules>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
                         <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
@@ -104,7 +104,7 @@
                     <configuration>
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <parent>
+        <groupId>com.adobe.commerce.cif</groupId>
+        <artifactId>cif-connector-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+        <relativePath>parent/pom.xml</relativePath>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.adobe.commerce.cif</groupId>
     <artifactId>cif-connector-reactor</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>CIF Connector Reactor</name>
     <description>Maven Multi-module project for the CIF connector project</description>
@@ -31,10 +36,25 @@
         <module>content/cif-connector</module>
         <module>bundles/cif-connector-graphql</module>
         <module>all</module>
-        <module>it/content</module>
-        <module>it/http</module>
-        <module>it/mock-server</module>
     </modules>
+    
+    <!-- We have a dedicated profile for integration tests -->
+    <!-- They are included by default unless we perform a release -->
+    <profiles>
+        <profile>
+            <id>integration-tests</id>
+            <activation>
+                <property>
+                    <name>!skip-it</name>
+                </property>
+            </activation>
+            <modules>
+                <module>it/content</module>
+                <module>it/http</module>
+                <module>it/mock-server</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <scm>
         <connection>scm:git:https://github.com/adobe/commerce-cif-connector.git</connection>


### PR DESCRIPTION
This PR changes the release strategy to a "reactor" release.

## How Has This Been Tested?

Tested locally that the reactor release works and does not release/deploy the integration tests artefacts.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
