### PR TITLE
Added .DS_Store and thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 *.iml
 pom.xml.releaseBackup
 release.properties
+
+# Directory Cache Files
+.DS_Store
+thumbs.db


### PR DESCRIPTION
## Description

`.DS_Store` is a MacOS directory cache file and `thumbs.db` is a windows directory cache file. 

## Motivation and Context

Sometimes Mac/Windows users accidentally push these files which may interfere with other Mac/Windows users.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
