### PR TITLE
CIF-1135 - Random concurrency error in ResourceMapper

### DIFF
--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/ResourceMapper.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/ResourceMapper.java
@@ -144,7 +144,7 @@ class ResourceMapper<T> {
     /**
      * This method builds various category caches used to lookup categories and products in a faster way.
      */
-    private void buildAllCategoryPaths() {
+    protected void buildAllCategoryPaths() {
         CategoryTree categoryTree = graphqlDataService.getCategoryTree(rootCategoryId, storeView);
         if (categoryTree == null || CollectionUtils.isEmpty(categoryTree.getChildren())) {
             LOGGER.warn("The Magento catalog is null or empty");

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/ResourceMapper.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/ResourceMapper.java
@@ -135,7 +135,9 @@ class ResourceMapper<T> {
                 x.getLocalizedMessage());
             LOGGER.warn("", x);
         } finally {
-            initLock.unlock();
+            if (initLock.isHeldByCurrentThread()) {
+                initLock.unlock();
+            }
         }
     }
 

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -164,12 +164,26 @@ public class GraphqlResourceProviderTest {
             }
         };
 
+        final Runnable schedulerJob = new Runnable() {
+            public void run() {
+                spy.refreshCache();
+            }
+        };
+
+        // One of the "init()" thread will initialize the cache, the other will block,
+        // and the scheduler thread will not be able to get the lock
+
         Thread t1 = new Thread(cacheRefreshJob);
         Thread t2 = new Thread(cacheRefreshJob);
+        Thread t3 = new Thread(schedulerJob);
+
         t1.start();
         t2.start();
+        t3.start();
+
         t1.join();
         t2.join();
+        t3.join();
 
         // With caching enabled, refreshCache() should be called only once by the 1st thread
         Mockito.verify(spy, Mockito.times(1)).refreshCache();

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -185,8 +185,11 @@ public class GraphqlResourceProviderTest {
         t2.join();
         t3.join();
 
-        // With caching enabled, refreshCache() should be called only once by the 1st thread
-        Mockito.verify(spy, Mockito.times(1)).refreshCache();
+        // With caching enabled, refreshCache() should be called only once by the 1st thread, and once by the scheduler
+        Mockito.verify(spy, Mockito.times(2)).refreshCache();
+
+        // With caching enabled, buildAllCategoryPaths() should be called only once by the 1st thread
+        Mockito.verify(spy, Mockito.times(1)).buildAllCategoryPaths();
     }
 
     @Test

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -185,9 +185,6 @@ public class GraphqlResourceProviderTest {
         t2.join();
         t3.join();
 
-        // With caching enabled, refreshCache() should be called only once by the 1st thread, and once by the scheduler
-        Mockito.verify(spy, Mockito.times(2)).refreshCache();
-
         // With caching enabled, buildAllCategoryPaths() should be called only once by the 1st thread
         Mockito.verify(spy, Mockito.times(1)).buildAllCategoryPaths();
     }


### PR DESCRIPTION
- make sure the lock was acquired before releasing it

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
