### PR TITLE
CIF-1171 - fix broken template editor

### DIFF
--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     categories="[cq.authoring.editor]"
-    dependencies="[granite.ui.coral.foundation,cq.authoring.editor.sites.page,commerce.gui.cifproductpicker]"/>
+    dependencies="[granite.ui.coral.foundation,commerce.gui.cifproductpicker]"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixed the broken template editor bug described at https://github.com/adobe/aem-cif-project-archetype/issues/60

## Related Issue

https://github.com/adobe/aem-cif-project-archetype/issues/60
CIF-117

## How Has This Been Tested?

manually checked if template editor is working and normal page editor still works including preview with product/category


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
