### PR TITLE
CIF-1247 - Product Picker bug

### DIFF
--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlQueries.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/magento/GraphqlQueries.java
@@ -73,6 +73,7 @@ class GraphqlQueries {
         .id()
         .sku()
         .name()
+        .urlKey()
         .updatedAt()
         .thumbnail(t -> t.url());
 

--- a/bundles/cif-connector-graphql/src/test/resources/graphql-queries/category-products.txt
+++ b/bundles/cif-connector-graphql/src/test/resources/graphql-queries/category-products.txt
@@ -1,1 +1,1 @@
-{category(id:19){products(sort:{name:ASC},currentPage:1,pageSize:10){total_count,items{__typename,id,sku,name,updated_at,thumbnail{url}}}}}
+{category(id:19){products(sort:{name:ASC},currentPage:1,pageSize:10){total_count,items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}}


### PR DESCRIPTION
 * added urlKey to base product query to make slug available in product picker

<!--- Provide a general summary of your changes in the Title above -->

## Description

Product picker didn't return product slug because the slug was missing from the underlying product resource and related GaphQL query.

## Related Issue

CIF-1247

## How Has This Been Tested?

Manually, unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
