### PR TITLE
CIF-1336 - CIF Connector build fails on Windows

### DIFF
--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/core/GraphqlProductViewHandlerTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/core/GraphqlProductViewHandlerTest.java
@@ -50,6 +50,8 @@ import static com.adobe.cq.commerce.graphql.search.CatalogSearchSupport.PN_CATAL
 
 public class GraphqlProductViewHandlerTest {
 
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+
     SlingHttpServletRequest servletRequest;
     ResourceResolver resourceResolver;
     TagManager tagManager;
@@ -182,11 +184,11 @@ public class GraphqlProductViewHandlerTest {
         // one hit with itemResourceType and resource
         hit.set("resource", Mockito.mock(Resource.class));
         output = viewHandler.generateHtmlOutput(hits, servletRequest, servletResponse);
-        Assert.assertEquals("Hit\n", output);
+        Assert.assertEquals("Hit" + LINE_SEPARATOR, output);
 
         // more hits with itemResourceType and resource
         hits.add(hit2);
         output = viewHandler.generateHtmlOutput(hits, servletRequest, servletResponse);
-        Assert.assertEquals("Hit\nHit\n", output);
+        Assert.assertEquals("Hit" + LINE_SEPARATOR + "Hit" + LINE_SEPARATOR, output);
     }
 }


### PR DESCRIPTION

## Description

Update the `GraphqlProductViewHandlerTest` to use `System.lineSeparator()` instead of hard-coding "\n" (fixes #107)

## Related Issue

CIF-1336

## Motivation and Context

Fix the build process on Windows platforms

## How Has This Been Tested?

Functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
