### PR TITLE
CIF-1327 - Show a "Create configuration folder" action in the CIF Configuration console

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -5,13 +5,13 @@ coverage:
       unittests:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: unittests
       karma:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: karma
     patch:
@@ -19,13 +19,13 @@ coverage:
       unittests:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: unittests
       karma:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: karma
 flags:

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItem.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItem.java
@@ -16,6 +16,7 @@ package com.adobe.cq.commerce.gui.components.configuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -25,7 +26,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,13 +43,16 @@ public class ConfigurationColumnViewItem {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationColumnViewItem.class);
 
-    @Self
-    private SlingHttpServletRequest request;
+    static final String CREATE_PULLDOWN_ACTIVATOR = "cq-confadmin-actions-create-pulldown-activator";
+    static final String CREATE_CONFIG_ACTIVATOR = "cq-confadmin-actions-create-config-activator";
+    static final String PROPERTIES_ACTIVATOR = "cq-confadmin-actions-properties-activator";
+    static final String CREATE_FOLDER_ACTIVATOR = "cq-confadmin-actions-create-folder-activator";
+    static final String DELETE_ACTIVATOR = "cq-confadmin-actions-delete-activator";
 
     @Inject
     private Resource resource;
 
-    boolean hasCommerceSetting;
+    private boolean hasCommerceSetting;
 
     @PostConstruct
     public void initModel() {
@@ -64,24 +67,44 @@ public class ConfigurationColumnViewItem {
     }
 
     public boolean hasChildren() {
+        if (isCommerceBucket())
+            return false;
+
         boolean isContainer = isConfigurationContainer();
-        return isContainer && hasCommerceSetting;
+        boolean hasChildren = resource.hasChildren();
+        boolean hasMoreChildren = StreamSupport.stream(resource.getChildren().spliterator(), false).count() > 1;
+        boolean hasSettings = resource.getChild("settings") != null;
+        return isContainer && (hasCommerceSetting || hasMoreChildren) || !isContainer && !hasCommerceSetting &&
+            (hasChildren && !hasSettings || hasMoreChildren && hasSettings);
+    }
+
+    private boolean isCommerceBucket() {
+        return resource.getPath().endsWith(Constants.COMMERCE_BUCKET_PATH);
     }
 
     public List<String> getQuickActionsRel() {
         List<String> actions = new ArrayList<>();
-
         if (isConfigurationContainer()) {
             // for /conf/<bucket>/settings folder we add the "Create" activator
             // so we can do a "client-side render condition"
-            actions.add(hasCommerceSetting || resource.getPath().equals(Constants.CONF_ROOT) ? "none"
-                : "cq-confadmin-actions-create-activator");
+            if (!hasCommerceSetting && !resource.getPath().equals(Constants.CONF_ROOT)) {
+                actions.add(CREATE_PULLDOWN_ACTIVATOR);
+                actions.add(CREATE_CONFIG_ACTIVATOR);
+            }
         }
 
-        if (!isConfigurationContainer()) {
+        if (isCommerceBucket()) {
             // for items which are not configuration containers (folders)
-            actions.add("cq-confadmin-actions-properties-activator");
-            actions.add("cq-confadmin-actions-delete-activator");
+            actions.add(PROPERTIES_ACTIVATOR);
+        } else {
+            if (!actions.contains(CREATE_PULLDOWN_ACTIVATOR)) {
+                actions.add(CREATE_PULLDOWN_ACTIVATOR);
+            }
+            actions.add(CREATE_FOLDER_ACTIVATOR);
+        }
+
+        if (isSafeToDelete()) {
+            actions.add(DELETE_ACTIVATOR);
         }
 
         return actions;
@@ -89,9 +112,21 @@ public class ConfigurationColumnViewItem {
 
     private boolean isConfigurationContainer() {
         return (resource.getPath()
-            .startsWith(Constants.CONF_ROOT) && (resource.isResourceType(JcrResourceConstants.NT_SLING_FOLDER) || resource.isResourceType(
-                JcrResourceConstants.NT_SLING_ORDERED_FOLDER))
+            .startsWith(Constants.CONF_ROOT) && (resource.isResourceType(JcrConstants.NT_FOLDER) ||
+                resource.isResourceType(JcrResourceConstants.NT_SLING_FOLDER) ||
+                resource.isResourceType(JcrResourceConstants.NT_SLING_ORDERED_FOLDER))
             && resource
                 .getChild(Constants.CONF_CONTAINER_BUCKET_NAME + "/" + Constants.CLOUDCONFIGS_BUCKET_NAME) != null);
+    }
+
+    private boolean isSafeToDelete() {
+        return isCommerceBucket() || resource.getPath().startsWith(Constants.CONF_ROOT)
+            && (resource.isResourceType(JcrResourceConstants.NT_SLING_FOLDER) ||
+                resource.isResourceType(JcrResourceConstants.NT_SLING_ORDERED_FOLDER))
+            && StreamSupport.stream(resource.getChildren().spliterator(), false).count() == 1
+            && resource.getChild(Constants.CONF_CONTAINER_BUCKET_NAME) != null
+            && StreamSupport.stream(resource.getChild(Constants.CONF_CONTAINER_BUCKET_NAME).getChildren().spliterator(), false).count() == 1
+            && resource.getChild(Constants.CONF_CONTAINER_BUCKET_NAME + "/" + Constants.CLOUDCONFIGS_BUCKET_NAME) != null
+            && !resource.getChild(Constants.CONF_CONTAINER_BUCKET_NAME + "/" + Constants.CLOUDCONFIGS_BUCKET_NAME).hasChildren();
     }
 }

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnPreviewTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnPreviewTest.java
@@ -42,7 +42,7 @@ public class ConfigurationColumnPreviewTest {
 
     @Before
     public void setUp() {
-        context.load().json("/context/jcr-conf-console.json", "/conf/testing");
+        context.load().json("/context/jcr-conf-console.json", "/conf");
 
         ExpressionResolver expressionResolver = Mockito.mock(ExpressionResolver.class);
         Mockito.when(expressionResolver.resolve(Mockito.any(String.class), Mockito.any(Locale.class), Mockito.any(Class.class), Mockito.any(

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItemTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItemTest.java
@@ -39,7 +39,7 @@ public class ConfigurationColumnViewItemTest {
 
     @Before
     public void setUp() {
-        context.load().json("/context/jcr-conf-console.json", "/conf/testing");
+        context.load().json("/context/jcr-conf-console.json", "/conf");
         context.addModelsForClasses(ConfigurationColumnViewItem.class);
     }
 
@@ -52,7 +52,7 @@ public class ConfigurationColumnViewItemTest {
     }
 
     @Test
-    public void testHasChildrenFalse() {
+    public void testHasChildrenOnConfiguration() {
         context.currentResource(context.resourceResolver().getResource(CONFIGURATION_PATH));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
@@ -60,11 +60,27 @@ public class ConfigurationColumnViewItemTest {
     }
 
     @Test
-    public void testHasChildrenTrue() {
+    public void testHasChildrenOnConfigurationParent() {
         context.currentResource(context.resourceResolver().getResource("/conf/testing"));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
-        Assert.assertTrue("Configuration has children", columnViewItem.hasChildren());
+        Assert.assertTrue("Configuration parent has children", columnViewItem.hasChildren());
+    }
+
+    @Test
+    public void testHasChildrenOnEmptyFolder() {
+        context.currentResource(context.resourceResolver().getResource("/conf/folder1"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        Assert.assertFalse("Empty folder has no children", columnViewItem.hasChildren());
+    }
+
+    @Test
+    public void testHasChildrenOnEmptyConfigFolder() {
+        context.currentResource(context.resourceResolver().getResource("/conf/folder2"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        Assert.assertFalse("Empty config folder has no children", columnViewItem.hasChildren());
     }
 
     @Test
@@ -79,12 +95,11 @@ public class ConfigurationColumnViewItemTest {
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();
         Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
-
     }
 
     @Test
     public void testGetQuickActionsForNoConfigurationFolder() {
-        context.currentResource(context.resourceResolver().getResource("/conf/testing/folder1"));
+        context.currentResource(context.resourceResolver().getResource("/conf/folder1"));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
         String[] expectedActions = new String[] {
@@ -94,12 +109,11 @@ public class ConfigurationColumnViewItemTest {
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();
         Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
-
     }
 
     @Test
     public void testGetQuickActionsForFolderWithoutConfiguration() {
-        context.currentResource(context.resourceResolver().getResource("/conf/testing/folder2"));
+        context.currentResource(context.resourceResolver().getResource("/conf/folder2"));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
         String[] expectedActions = new String[] {
@@ -111,7 +125,34 @@ public class ConfigurationColumnViewItemTest {
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();
         Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
+    }
 
+    @Test
+    public void testGetQuickActionsForFolderWithoutConfigurationAndWithFolder() {
+        context.currentResource(context.resourceResolver().getResource("/conf/folder3"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR,
+        };
+
+        List<String> actualActions = columnViewItem.getQuickActionsRel();
+        Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
+    }
+
+    @Test
+    public void testGetQuickActionsOnConfRoot() {
+        context.currentResource(context.resourceResolver().getResource("/conf"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR,
+        };
+
+        List<String> actualActions = columnViewItem.getQuickActionsRel();
+        Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
     }
 
     @Test
@@ -126,6 +167,5 @@ public class ConfigurationColumnViewItemTest {
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();
         Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
-
     }
 }

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItemTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItemTest.java
@@ -84,6 +84,14 @@ public class ConfigurationColumnViewItemTest {
     }
 
     @Test
+    public void testHasChildrenOnNonEmptyConfigFolder() {
+        context.currentResource(context.resourceResolver().getResource("/conf/folder4"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        Assert.assertTrue("Empty config folder has no children", columnViewItem.hasChildren());
+    }
+
+    @Test
     public void testGetQuickActionsForFolderWithConfiguration() {
         context.currentResource(context.resourceResolver().getResource("/conf/testing"));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
@@ -142,13 +150,41 @@ public class ConfigurationColumnViewItemTest {
     }
 
     @Test
+    public void testGetQuickActionsOnEmptyFolder() {
+        context.currentResource(context.resourceResolver().getResource("/conf/folder3/folder1"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR,
+        };
+
+        List<String> actualActions = columnViewItem.getQuickActionsRel();
+        Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
+    }
+
+    @Test
+    public void testGetQuickActionsFolderWithSettingsOnly() {
+        context.currentResource(context.resourceResolver().getResource("/conf/folder3/folder2"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR,
+        };
+
+        List<String> actualActions = columnViewItem.getQuickActionsRel();
+        Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
+    }
+
+    @Test
     public void testGetQuickActionsOnConfRoot() {
         context.currentResource(context.resourceResolver().getResource("/conf"));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
         String[] expectedActions = new String[] {
             CREATE_PULLDOWN_ACTIVATOR,
-            CREATE_FOLDER_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR
         };
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItemTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/configuration/ConfigurationColumnViewItemTest.java
@@ -25,6 +25,12 @@ import org.junit.Test;
 
 import io.wcm.testing.mock.aem.junit.AemContext;
 
+import static com.adobe.cq.commerce.gui.components.configuration.ConfigurationColumnViewItem.CREATE_CONFIG_ACTIVATOR;
+import static com.adobe.cq.commerce.gui.components.configuration.ConfigurationColumnViewItem.CREATE_FOLDER_ACTIVATOR;
+import static com.adobe.cq.commerce.gui.components.configuration.ConfigurationColumnViewItem.CREATE_PULLDOWN_ACTIVATOR;
+import static com.adobe.cq.commerce.gui.components.configuration.ConfigurationColumnViewItem.DELETE_ACTIVATOR;
+import static com.adobe.cq.commerce.gui.components.configuration.ConfigurationColumnViewItem.PROPERTIES_ACTIVATOR;
+
 public class ConfigurationColumnViewItemTest {
 
     public static final String CONFIGURATION_PATH = "/conf/testing/settings/cloudconfigs/commerce";
@@ -66,7 +72,42 @@ public class ConfigurationColumnViewItemTest {
         context.currentResource(context.resourceResolver().getResource("/conf/testing"));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
-        String[] expectedActions = new String[] { "none" };
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR
+        };
+
+        List<String> actualActions = columnViewItem.getQuickActionsRel();
+        Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
+
+    }
+
+    @Test
+    public void testGetQuickActionsForNoConfigurationFolder() {
+        context.currentResource(context.resourceResolver().getResource("/conf/testing/folder1"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR
+        };
+
+        List<String> actualActions = columnViewItem.getQuickActionsRel();
+        Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
+
+    }
+
+    @Test
+    public void testGetQuickActionsForFolderWithoutConfiguration() {
+        context.currentResource(context.resourceResolver().getResource("/conf/testing/folder2"));
+        ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
+
+        String[] expectedActions = new String[] {
+            CREATE_PULLDOWN_ACTIVATOR,
+            CREATE_CONFIG_ACTIVATOR,
+            CREATE_FOLDER_ACTIVATOR,
+            DELETE_ACTIVATOR
+        };
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();
         Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());
@@ -78,7 +119,10 @@ public class ConfigurationColumnViewItemTest {
         context.currentResource(context.resourceResolver().getResource(CONFIGURATION_PATH));
         ConfigurationColumnViewItem columnViewItem = context.request().adaptTo(ConfigurationColumnViewItem.class);
 
-        String[] expectedActions = new String[] { "cq-confadmin-actions-properties-activator", "cq-confadmin-actions-delete-activator" };
+        String[] expectedActions = new String[] {
+            PROPERTIES_ACTIVATOR,
+            DELETE_ACTIVATOR
+        };
 
         List<String> actualActions = columnViewItem.getQuickActionsRel();
         Assert.assertArrayEquals("Returns the quick-actions", expectedActions, actualActions.toArray());

--- a/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
@@ -17,5 +17,17 @@
         }
       }
     }
+  },
+  "folder1": {
+    "jcr:primaryType": "sling:Folder"
+  },
+  "folder2": {
+    "jcr:primaryType": "sling:OrderedFolder",
+    "settings": {
+      "jcr:primaryType": "sling:Folder",
+      "cloudconfigs": {
+        "jcr:primaryType": "sling:Folder"
+      }
+    }
   }
 }

--- a/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
@@ -48,6 +48,9 @@
       "jcr:primaryType": "sling:OrderedFolder",
       "settings": {
         "jcr:primaryType": "sling:Folder"
+      },
+      "folder1": {
+        "jcr:primaryType": "nt:folder"
       }
     }
   },

--- a/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
@@ -48,9 +48,6 @@
       "jcr:primaryType": "sling:OrderedFolder",
       "settings": {
         "jcr:primaryType": "sling:Folder"
-      },
-      "folder1": {
-        "jcr:primaryType": "nt:folder"
       }
     }
   },

--- a/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
@@ -1,5 +1,5 @@
 {
-  "jcr:primaryType": "sling:Folder",
+  "jcr:primaryType": "nt:folder",
   "testing": {
     "jcr:primaryType": "sling:Folder",
     "settings": {
@@ -43,6 +43,24 @@
     "jcr:primaryType": "sling:OrderedFolder",
     "folder1": {
       "jcr:primaryType": "sling:OrderedFolder"
+    },
+    "folder2": {
+      "jcr:primaryType": "sling:OrderedFolder",
+      "settings": {
+        "jcr:primaryType": "sling:Folder"
+      }
+    }
+  },
+  "folder4": {
+    "jcr:primaryType": "sling:OrderedFolder",
+    "settings": {
+      "jcr:primaryType": "sling:Folder",
+      "cloudconfigs": {
+        "jcr:primaryType": "sling:Folder"
+      }
+    },
+    "folder1": {
+      "jcr:primaryType": "sling:Folder"
     }
   }
 }

--- a/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
+++ b/bundles/cif-connector-graphql/src/test/resources/context/jcr-conf-console.json
@@ -1,21 +1,30 @@
 {
   "jcr:primaryType": "sling:Folder",
+  "testing": {
+    "jcr:primaryType": "sling:Folder",
+    "settings": {
+      "jcr:primaryType": "sling:Folder",
+      "cloudconfigs": {
+        "jcr:primaryType": "sling:Folder",
+        "commerce": {
+          "jcr:primaryType": "cq:Page",
+          "jcr:content": {
+            "jcr:title": "Mock configuration",
+            "magentoRootCategoryId": "4",
+            "cq:graphqlClient": "default",
+            "cq:catalogIdentifier": "my-catalog",
+            "magentoStore": "4",
+            "jcr:created": "Thu Feb 06 2020 14:21:13 GMT+0200",
+            "cq:catalogDataResourceProviderFactory": "magento-graphql"
+          }
+        }
+      }
+    }
+  },
   "settings": {
     "jcr:primaryType": "sling:Folder",
     "cloudconfigs": {
-      "jcr:primaryType": "sling:Folder",
-      "commerce": {
-        "jcr:primaryType": "cq:Page",
-        "jcr:content": {
-          "jcr:title": "Mock configuration",
-          "magentoRootCategoryId": "4",
-          "cq:graphqlClient": "default",
-          "cq:catalogIdentifier": "my-catalog",
-          "magentoStore": "4",
-          "jcr:created": "Thu Feb 06 2020 14:21:13 GMT+0200",
-          "cq:catalogDataResourceProviderFactory": "magento-graphql"
-        }
-      }
+      "jcr:primaryType": "sling:Folder"
     }
   },
   "folder1": {
@@ -28,6 +37,12 @@
       "cloudconfigs": {
         "jcr:primaryType": "sling:Folder"
       }
+    }
+  },
+  "folder3": {
+    "jcr:primaryType": "sling:OrderedFolder",
+    "folder1": {
+      "jcr:primaryType": "sling:OrderedFolder"
     }
   }
 }

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/clientlibs/configbrowser/js.txt
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/clientlibs/configbrowser/js.txt
@@ -1,3 +1,3 @@
 #base=js
 actions/delete.js
-renderconditions/hascommerceconfig.js
+renderconditions/renderconditions.js

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/clientlibs/configbrowser/js/renderconditions/renderconditions.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/clientlibs/configbrowser/js/renderconditions/renderconditions.js
@@ -51,15 +51,21 @@
 
         const createPullDown = document.querySelector(CREATE_PULLDOWN_SELECTOR);
         hide(createPullDown);
-        if (actionRels && createPullDown && actionRels.indexOf(CREATE_PULLDOWN_REL) >= 0) show(createPullDown);
+        if (actionRels && createPullDown && actionRels.indexOf(CREATE_PULLDOWN_REL) >= 0) {
+            show(createPullDown);
+        }
 
         const createFolderButton = document.querySelector(CREATE_FOLDER_SELECTOR);
         hide(createFolderButton);
-        if (actionRels && createFolderButton && actionRels.indexOf(CREATE_FOLDER_REL) >= 0) show(createFolderButton);
+        if (actionRels && createFolderButton && actionRels.indexOf(CREATE_FOLDER_REL) >= 0) {
+            show(createFolderButton);
+        }
 
         const createConfigButton = document.querySelector(CREATE_CONFIG_SELECTOR);
         hide(createConfigButton);
-        if (actionRels && createConfigButton && actionRels.indexOf(CREATE_CONFIG_REL) >= 0) show(createConfigButton);
+        if (actionRels && createConfigButton && actionRels.indexOf(CREATE_CONFIG_REL) >= 0) {
+            show(createConfigButton);
+        }
     }
 
     function init() {

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/clientlibs/configbrowser/js/renderconditions/renderconditions.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/clientlibs/configbrowser/js/renderconditions/renderconditions.js
@@ -11,43 +11,58 @@
  */
 
 (function($) {
+    const CREATE_PULLDOWN_SELECTOR = '.cif-create-pulldown';
     const CREATE_CONFIG_SELECTOR = '.cif-create-config';
-    const REL_CREATE_CONFIG_NONE = 'none';
-    const REL_CREATE_CONFIG = 'cq-confadmin-actions-create-activator';
+    const CREATE_FOLDER_SELECTOR = '.cif-create-folder';
+    const CREATE_PULLDOWN_REL = 'cq-confadmin-actions-create-pulldown-activator';
+    const CREATE_CONFIG_REL = 'cq-confadmin-actions-create-config-activator';
+    const CREATE_FOLDER_REL = 'cq-confadmin-actions-create-folder-activator';
 
     $(document).on('foundation-contentloaded', event => {
-        initCreateConfig();
+        init();
     });
     $(document).on('foundation-selections-change', function(e) {
-        const createConfigButton = document.querySelector(CREATE_CONFIG_SELECTOR);
-        hide(createConfigButton);
+        const createPulldown = document.querySelector(CREATE_PULLDOWN_SELECTOR);
+        hide(createPulldown);
         if (e.target.activeItem) {
             const activeItem = e.target.activeItem;
-            checkCreateConfig(activeItem);
+            applyRenderConditions(activeItem);
         }
     });
 
     function hide(element) {
-        element.style.display = 'none';
+        if (element) {
+            element.style.display = 'none';
+        }
     }
 
     function show(element) {
-        element.style.display = 'block';
+        if (element) {
+            element.style.display = 'block';
+        }
     }
 
-    function checkCreateConfig(activeItem) {
+    function applyRenderConditions(activeItem) {
         const activeItemMeta = activeItem.querySelector('.foundation-collection-quickactions');
-        let relAction;
+        let actionRels;
         if (activeItemMeta) {
-            relAction = activeItemMeta.dataset['foundationCollectionQuickactionsRel'];
+            actionRels = activeItemMeta.dataset['foundationCollectionQuickactionsRel'];
         }
+
+        const createPullDown = document.querySelector(CREATE_PULLDOWN_SELECTOR);
+        hide(createPullDown);
+        if (actionRels && createPullDown && actionRels.indexOf(CREATE_PULLDOWN_REL) >= 0) show(createPullDown);
+
+        const createFolderButton = document.querySelector(CREATE_FOLDER_SELECTOR);
+        hide(createFolderButton);
+        if (actionRels && createFolderButton && actionRels.indexOf(CREATE_FOLDER_REL) >= 0) show(createFolderButton);
+
         const createConfigButton = document.querySelector(CREATE_CONFIG_SELECTOR);
         hide(createConfigButton);
-        if (relAction && createConfigButton && relAction === REL_CREATE_CONFIG_NONE) hide(createConfigButton);
-        if (relAction && createConfigButton && relAction === REL_CREATE_CONFIG) show(createConfigButton);
+        if (actionRels && createConfigButton && actionRels.indexOf(CREATE_CONFIG_REL) >= 0) show(createConfigButton);
     }
 
-    function initCreateConfig() {
+    function init() {
         //Default content path
         const activeItem = document.querySelector('.cq-confadmin-admin-childpages.foundation-collection');
         if (activeItem) {
@@ -62,10 +77,10 @@
                             contentPath === objElement.dataset['foundationCollectionId'] ||
                             contentPath === objElement.dataset['foundationCollectionId'] + '/'
                         )
-                            checkCreateConfig(objElement);
+                            applyRenderConditions(objElement);
                     });
                 } else {
-                    checkCreateConfig(activeItem);
+                    applyRenderConditions(activeItem);
                 }
             });
         }

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/configuration/columnviewitem/columnviewitem.html
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/configuration/columnviewitem/columnviewitem.html
@@ -23,5 +23,5 @@
             ${configuration.title}
         </div>
     </coral-columnview-item-content>
-    <meta class="foundation-collection-quickactions" data-foundation-collection-quickactions-rel="${configuration.quickActionsRel.isEmpty ? 'none' : configuration.quickActionsRel @join=' '}">
+    <meta class="foundation-collection-quickactions" data-foundation-collection-quickactions-rel="${configuration.quickActionsRel @join=' '}">
 </coral-columnview-item>

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/content/configuration/.content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/content/configuration/.content.xml
@@ -17,8 +17,8 @@
                  targetCollection=".cq-confadmin-admin-childpages">
         <head jcr:primaryType="nt:unstructured">
             <clientlibs jcr:primaryType="nt:unstructured"
-                        categories="[cq.common.wcm, cq.sites.collectionpage,commerce.gui.admin.configconsole]"
-                        sling:resourceType="granite/ui/components/foundation/includeclientlibs"/>
+                        categories="[cq.common.wcm, cq.sites.collectionpage,commerce.gui.admin.configconsole,granite.conf.ui.browser]"
+                        sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"/>
         </head>
         <views jcr:primaryType="nt:unstructured">
             <column jcr:primaryType="nt:unstructured"
@@ -51,16 +51,37 @@
         <actions jcr:primaryType="nt:unstructured">
             <primary jcr:primaryType="nt:unstructured"/>
             <secondary jcr:primaryType="nt:unstructured">
-                <create jcr:primaryType="nt:unstructured"
-                        granite:class="cq-confadmin-actions-createconfig-activator cif-create-config"
-                        relScope="collection"
-                        sling:resourceType="granite/ui/components/coral/foundation/collection/action"
-                        action="foundation.link"
-                        target=".cq-confadmin-admin-childpages"
-                        text="Create configuration"
-                        variant="primary">
-                    <data jcr:primaryType="nt:unstructured"
-                          href.uritemplate="/mnt/overlay/commerce/gui/content/configuration/createconfiguration.html{+id}"/>
+                <create
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/pulldown"
+                    granite:rel="cq-confadmin-actions-create-folder-activator"
+                    granite:class="cq-confadmin-actions-create-pulldown-activator cif-create-pulldown"
+                    text="Create"
+                    variant="primary">
+                    <items jcr:primaryType="nt:unstructured">
+                        <createFolder jcr:primaryType="nt:unstructured"
+                            granite:rel="cq-confadmin-actions-create-folder-activator"
+                            granite:class="cq-confadmin-actions-create-folder-activator cif-create-folder"
+                            sling:resourceType="granite/ui/components/coral/foundation/collection/actionlink"
+                            relScope="collection"
+                            ignoreRel="{Boolean}false"
+                            action="create.conf.action"
+                            target=".cq-confadmin-admin-childpages"
+                            text="Configuration Folder"
+                            variant="primary">
+                        </createFolder>
+                        <createConfig jcr:primaryType="nt:unstructured"
+                            granite:class="cq-confadmin-actions-create-config-activator cif-create-config"
+                            relScope="collection"
+                            sling:resourceType="granite/ui/components/coral/foundation/collection/actionlink"
+                            action="foundation.link"
+                            target=".cq-confadmin-admin-childpages"
+                            text="Commerce Configuration"
+                            variant="primary">
+                            <data jcr:primaryType="nt:unstructured"
+                                  href.uritemplate="/mnt/overlay/commerce/gui/content/configuration/createconfiguration.html{+id}"/>
+                        </createConfig>
+                    </items>
                 </create>
             </secondary>
             <selection jcr:primaryType="nt:unstructured">
@@ -88,6 +109,68 @@
             </selection>
 
         </actions>
+        <footer
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/container">
+            <items jcr:primaryType="nt:unstructured">
+                <configParent jcr:primaryType="nt:unstructured"
+                              granite:id="view-configs-suffix"
+                              sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                              value="${requestPathInfo.suffix}"/>
+                <createConfigurationDialog
+                        granite:id="create-config-dialog"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Create Configuration Folder"
+                        sling:resourceType="granite/ui/components/coral/foundation/dialog">
+                    <items jcr:primaryType="nt:unstructured">
+                        <createConfigurationForm
+                                granite:id="create-config-form"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form"
+                                autosubmitForm="{Boolean}false"
+                                action="${granite:encodeURIPath(requestPathInfo.suffix)}.createconf.json"
+                                style="vertical">
+                            <items jcr:primaryType="nt:unstructured">
+                                <title jcr:primaryType="nt:unstructured"
+                                       sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                       fieldLabel="Title"
+                                       required="{Boolean}true"
+                                       name="configTitle"/>
+                                <capabilities jcr:primaryType="nt:unstructured"
+                                      sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                      name="configCapabilities"
+                                      value="Cloud Configurations"/>
+                                <configParent
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                        name="configParent"/>
+                                <charset jcr:primaryType="nt:unstructured"
+                                         sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                         name="_charset_"
+                                         value="utf-8"/>
+                            </items>
+                        </createConfigurationForm>
+                    </items>
+                    <footer jcr:primaryType="nt:unstructured">
+                        <cancel
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/button"
+                                text="Cancel">
+                            <parentConfig
+                                    jcr:primaryType="nt:unstructured"
+                                    close="{Boolean}true"/>
+                        </cancel>
+                        <ok
+                                granite:id="create-configuration-button-confirm"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/button"
+                                text="Create"
+                                disabled="{Boolean}true"
+                                variant="primary"/>
+                    </footer>
+                </createConfigurationDialog>
+            </items>
+        </footer>
     </jcr:content>
     <columnpreview jcr:primaryType="nt:unstructured"
                    path="${requestPathInfo.suffix}"


### PR DESCRIPTION
 * implemented create configuration folder action
 * grouped create actions in create pull-down
 * adjusted display logic for displaying empty configuration folders
 * adjusted delete action for removing empty configuration folders
 * clarified render conditions
 * updated unit tests

## Description

The "Create configuration folder" action should be available in the CIF Configuration console to avoid switching between consoles.

Ideally the new configuration folder would already have the settings/cloudservices subtree created instead of the user explicitly selecting "Cloud Services" from the dialog.

## Related Issue

CIF-1327

## How Has This Been Tested?

Manually, JUnit.

## Screenshots (if appropriate):

![screenshot1](https://user-images.githubusercontent.com/5930208/80364275-4e61fe80-888e-11ea-8f0a-52dcf48c244d.png)

![screenshot2](https://user-images.githubusercontent.com/5930208/80364286-5457df80-888e-11ea-8790-01bb47ef5703.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
