### PR TITLE
CIF-1325	- Automatically create a product binding after creating a configuration

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -5,13 +5,13 @@ coverage:
       unittests:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: unittests
       karma:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: karma
     patch:
@@ -19,13 +19,13 @@ coverage:
       unittests:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: unittests
       karma:
         enabled: true
         target: 80%
-        threshold: null
+        threshold: 10%
         base: auto
         flags: karma
 flags:

--- a/bundles/cif-virtual-catalog/pom.xml
+++ b/bundles/cif-virtual-catalog/pom.xml
@@ -188,19 +188,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.sling</groupId>-->
-        <!--            <artifactId>org.apache.sling.testing.sling-mock</artifactId>-->
-        <!--            <version>2.3.18</version>-->
-        <!--            <scope>test</scope>-->
-        <!--            <exclusions>-->
-        <!--                &lt;!&ndash; Exclude the older version of the API and use the one from the uber-jar &ndash;&gt;-->
-        <!--                <exclusion>-->
-        <!--                    <groupId>org.apache.sling</groupId>-->
-        <!--                    <artifactId>org.apache.sling.models.api</artifactId>-->
-        <!--                </exclusion>-->
-        <!--            </exclusions>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
@@ -260,12 +247,6 @@
             <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
             <version>2.1.6</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.sling</groupId>
-                    <artifactId>org.apache.sling.jcr.resource</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
@@ -217,6 +217,10 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
             ConfigurationBuilder cfgBuilder = root.adaptTo(ConfigurationBuilder.class);
             ValueMap properties = cfgBuilder.name(CONFIGURATION_NAME).asValueMap();
             providerId = properties.get(CatalogDataResourceProviderFactory.PROPERTY_FACTORY_ID, String.class);
+            if (providerId == null) {
+                log.warn("No {} configured, nothing to register here", CatalogDataResourceProviderFactory.PROPERTY_FACTORY_ID);
+                return false;
+            }
             log.debug("Configured provider id is {}", providerId);
             factory = providerFactories.get(providerId);
         } else {

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ *
+ *
+ *      Copyright 2020 Adobe. All rights reserved.
+ *      This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License. You may obtain a copy
+ *      of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software distributed under
+ *      the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *      OF ANY KIND, either express or implied. See the License for the specific language
+ *      governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.virtual.catalog.data.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChangeListener;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.commerce.virtual.catalog.data.Constants;
+import com.day.cq.commons.jcr.JcrConstants;
+
+@Component(
+    service = ResourceChangeListener.class,
+    property = { ResourceChangeListener.PATHS + "=glob:/conf/**/*",
+        ResourceChangeListener.CHANGES + "=REMOVED",
+        ResourceChangeListener.CHANGES + "=ADDED" })
+public class ProductBindingCreator implements ResourceChangeListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProductBindingCreator.class);
+    private static final String VIRTUAL_PRODUCTS_SERVICE = "virtual-products-service";
+    private static final String BINDINGS_PARENT_PATH = "/var/commerce/products";
+
+    private ResourceResolver resolver;
+
+    @Reference
+    private ResourceResolverFactory resolverFactory = null;
+
+    protected void activate(final ComponentContext context) throws LoginException {
+        LOG.debug("Activating the component");
+        final Map<String, Object> map = new HashMap<>();
+        map.put(ResourceResolverFactory.SUBSERVICE, VIRTUAL_PRODUCTS_SERVICE);
+        resolver = resolverFactory.getServiceResourceResolver(map);
+        LOG.debug("Do we have a resolver? {}", resolver != null);
+    }
+
+    protected void deactivate() {
+        resolver.close();
+    }
+
+    @Override
+    public void onChange(List<ResourceChange> list) {
+        LOG.debug("Change detected somewhere...");
+        list.stream().filter(change -> {
+            String path = change.getPath();
+            LOG.debug("Processing path {}", path);
+            return !path.endsWith(JcrConstants.JCR_CONTENT) && path.contains(Constants.COMMERCE_BUCKET_PATH);
+        }).forEach(change -> {
+            if (change.getType() == ResourceChange.ChangeType.ADDED) {
+                processAddition(change);
+            } else if (change.getType() == ResourceChange.ChangeType.REMOVED) {
+                processRemoval(change);
+            }
+        });
+        try {
+            resolver.commit();
+        } catch (PersistenceException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    private void processAddition(ResourceChange change) {
+        String path = change.getPath();
+        LOG.debug("Process resource addition at path {}", path);
+
+        Resource changedResource = resolver.getResource(path);
+        Resource contentResource = changedResource.getChild(JcrConstants.JCR_CONTENT);
+
+        ValueMap properties;
+        if (contentResource != null) {
+            properties = contentResource.getValueMap();
+        } else {
+            properties = changedResource.getValueMap();
+        }
+
+        String storeView = properties.get("magentoStore", "");
+        if (StringUtils.isEmpty(storeView)) {
+            LOG.warn("The configuration at path {} doesn't have a 'storeView' property");
+            return;
+        }
+
+        String configRoot = path.substring(0, path.indexOf(Constants.COMMERCE_BUCKET_PATH) - 1);
+        String configName = configRoot.substring(configRoot.lastIndexOf("/") + 1);
+
+        String bindingName = configName + "-" + storeView;
+        LOG.debug("New binding name: {}", bindingName);
+
+        Map<String, Object> mappingProperties = new HashMap<>();
+        mappingProperties.put("jcr:primaryType", "sling:Folder");
+        mappingProperties.put("jcr:title", bindingName);
+        mappingProperties.put("cq:conf", configRoot);
+
+        Resource parent = resolver.getResource(BINDINGS_PARENT_PATH);
+        if (parent == null) {
+            LOG.warn("Binding parent path not found at {}. Nothing to do here...", BINDINGS_PARENT_PATH);
+            return;
+        }
+
+        try {
+            LOG.debug("Creating a new resource at {}, properties are ", parent.getPath() + "/" + bindingName, mappingProperties);
+            resolver.create(parent, bindingName, mappingProperties);
+        } catch (PersistenceException e) {
+            LOG.error(e.getMessage(), e);
+        }
+
+    }
+
+    private void processRemoval(ResourceChange change) {
+        LOG.debug("Processing resource removal at {}", change.getPath());
+    }
+
+}

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
@@ -45,7 +45,7 @@ import com.day.cq.commons.jcr.JcrConstants;
 public class ProductBindingCreator implements ResourceChangeListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProductBindingCreator.class);
-    private static final String VIRTUAL_PRODUCTS_SERVICE = "virtual-products-service";
+    private static final String PRODUCT_BINDING_SERVICE = "product-binding-service";
     private static final String BINDINGS_PARENT_PATH = "/var/commerce/products";
 
     private ResourceResolver resolver;
@@ -56,7 +56,7 @@ public class ProductBindingCreator implements ResourceChangeListener {
     protected void activate(final ComponentContext context) throws LoginException {
         LOG.debug("Activating the component");
         final Map<String, Object> map = new HashMap<>();
-        map.put(ResourceResolverFactory.SUBSERVICE, VIRTUAL_PRODUCTS_SERVICE);
+        map.put(ResourceResolverFactory.SUBSERVICE, PRODUCT_BINDING_SERVICE);
         resolver = resolverFactory.getServiceResourceResolver(map);
         LOG.debug("Do we have a resolver? {}", resolver != null);
     }

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
@@ -106,9 +106,9 @@ public class ProductBindingCreator implements ResourceChangeListener {
         LOG.debug("New binding name: {}", bindingName);
 
         Map<String, Object> mappingProperties = new HashMap<>();
-        mappingProperties.put("jcr:primaryType", "sling:Folder");
-        mappingProperties.put("jcr:title", bindingName);
-        mappingProperties.put("cq:conf", configRoot);
+        mappingProperties.put(JcrConstants.JCR_PRIMARYTYPE, "sling:Folder");
+        mappingProperties.put(JcrConstants.JCR_TITLE, bindingName);
+        mappingProperties.put(Constants.PN_CONF, configRoot);
 
         Resource parent = resolver.getResource(BINDINGS_PARENT_PATH);
         if (parent == null) {

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
@@ -75,15 +75,8 @@ public class ProductBindingCreator implements ResourceChangeListener {
         }).forEach(change -> {
             if (change.getType() == ResourceChange.ChangeType.ADDED) {
                 processAddition(change);
-            } else if (change.getType() == ResourceChange.ChangeType.REMOVED) {
-                processRemoval(change);
             }
         });
-        try {
-            resolver.commit();
-        } catch (PersistenceException e) {
-            LOG.error(e.getMessage(), e);
-        }
     }
 
     private void processAddition(ResourceChange change) {
@@ -100,9 +93,9 @@ public class ProductBindingCreator implements ResourceChangeListener {
             properties = changedResource.getValueMap();
         }
 
-        String storeView = properties.get("magentoStore", "");
+        String storeView = properties.get(Constants.PN_MAGENTO_STORE, "");
         if (StringUtils.isEmpty(storeView)) {
-            LOG.warn("The configuration at path {} doesn't have a 'storeView' property");
+            LOG.warn("The configuration at path {} doesn't have a '{}' property", path, Constants.PN_MAGENTO_STORE);
             return;
         }
 
@@ -124,16 +117,13 @@ public class ProductBindingCreator implements ResourceChangeListener {
         }
 
         try {
-            LOG.debug("Creating a new resource at {}, properties are ", parent.getPath() + "/" + bindingName, mappingProperties);
+            LOG.debug("Creating a new resource at {}", parent.getPath() + "/" + bindingName);
             resolver.create(parent, bindingName, mappingProperties);
+            resolver.commit();
         } catch (PersistenceException e) {
             LOG.error(e.getMessage(), e);
         }
 
-    }
-
-    private void processRemoval(ResourceChange change) {
-        LOG.debug("Processing resource removal at {}", change.getPath());
     }
 
 }

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataProviderManagerConfTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataProviderManagerConfTest.java
@@ -82,6 +82,7 @@ public class CatalogDataProviderManagerConfTest {
         // load sample content
         context.load().json("/context/jcr-conf.json", "/conf/testing/settings");
         context.load().json("/context/jcr-dataroots.json", COMMERCE_ROOT);
+        context.load().json("/context/jcr-wrong-conf.json", "/conf/wrong-configuration/settings");
 
         // register the services
         context.registerService(new MockResourceResolverFactory());
@@ -98,7 +99,7 @@ public class CatalogDataProviderManagerConfTest {
         String expectedDataRootPath = COMMERCE_ROOT + "/products/" + NN_DATA_ROOT;
 
         List<Resource> dataRoots = manager.getDataRoots();
-        Assert.assertEquals("The manager found two data roots", 2, dataRoots.size());
+        Assert.assertEquals("The manager found two data roots", 3, dataRoots.size());
 
         Resource dataRoot = dataRoots.get(0);
         Assert.assertEquals("The data root points to " + expectedDataRootPath, expectedDataRootPath, dataRoot.getPath());

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ *
+ *
+ *      Copyright 2020 Adobe. All rights reserved.
+ *      This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License. You may obtain a copy
+ *      of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software distributed under
+ *      the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *      OF ANY KIND, either express or implied. See the License for the specific language
+ *      governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.virtual.catalog.data.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.commons.cnd.CndImporter;
+import org.apache.jackrabbit.commons.cnd.ParseException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChangeListener;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.day.cq.wcm.api.WCMException;
+import com.day.util.diff.Diff;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit.AemContextBuilder;
+
+public class ProductBindingCreatorTest {
+
+    @Rule
+    public AemContext context = new AemContextBuilder(ResourceResolverType.JCR_OAK).build();
+    private ProductBindingCreator creator;
+    @Before
+    public void setup() throws ParseException, RepositoryException, IOException {
+        context.create().resource("/var/commerce/products");
+        context.load().json("/context/jcr-conf-page.json","/conf/testing/settings");
+
+        creator = new ProductBindingCreator();
+        context.registerInjectActivateService(creator);
+    }
+
+    @Test
+    public void testCreateBindingWhenConfigurationIsCreated() throws WCMException, PersistenceException {
+        Assert.assertNotNull(context.resourceResolver().getResource("/conf/testing/settings/cloudconfigs"));
+
+        ResourceChange change = new ResourceChange(ResourceChange.ChangeType.ADDED,"/conf/testing/settings/cloudconfigs/commerce",false );
+
+        creator.onChange(ImmutableList.of(change));
+
+        Assert.assertNotNull(context.resourceResolver().getResource("/var/commerce/products/testing-english"));
+        Assert.assertTrue(true);
+    }
+}

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
@@ -16,18 +16,12 @@
 package com.adobe.cq.commerce.virtual.catalog.data.impl;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.Map;
 
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
-import org.apache.jackrabbit.commons.cnd.CndImporter;
 import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.observation.ResourceChange;
-import org.apache.sling.api.resource.observation.ResourceChangeListener;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,9 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.day.cq.wcm.api.WCMException;
-import com.day.util.diff.Diff;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
 import io.wcm.testing.mock.aem.junit.AemContextBuilder;
 
@@ -46,10 +38,11 @@ public class ProductBindingCreatorTest {
     @Rule
     public AemContext context = new AemContextBuilder(ResourceResolverType.JCR_OAK).build();
     private ProductBindingCreator creator;
+
     @Before
     public void setup() throws ParseException, RepositoryException, IOException {
         context.create().resource("/var/commerce/products");
-        context.load().json("/context/jcr-conf-page.json","/conf/testing/settings");
+        context.load().json("/context/jcr-conf-page.json", "/conf/testing/settings");
 
         creator = new ProductBindingCreator();
         context.registerInjectActivateService(creator);
@@ -59,7 +52,7 @@ public class ProductBindingCreatorTest {
     public void testCreateBindingWhenConfigurationIsCreated() throws WCMException, PersistenceException {
         Assert.assertNotNull(context.resourceResolver().getResource("/conf/testing/settings/cloudconfigs"));
 
-        ResourceChange change = new ResourceChange(ResourceChange.ChangeType.ADDED,"/conf/testing/settings/cloudconfigs/commerce",false );
+        ResourceChange change = new ResourceChange(ResourceChange.ChangeType.ADDED, "/conf/testing/settings/cloudconfigs/commerce", false);
 
         creator.onChange(ImmutableList.of(change));
 

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
@@ -41,8 +41,8 @@ public class ProductBindingCreatorTest {
 
     @Before
     public void setup() throws ParseException, RepositoryException, IOException {
-        context.create().resource("/var/commerce/products");
         context.load().json("/context/jcr-conf-page.json", "/conf/testing/settings");
+        context.load().json("/context/jcr-catalog-bindings.json", "/var/commerce");
 
         creator = new ProductBindingCreator();
         context.registerInjectActivateService(creator);
@@ -58,5 +58,14 @@ public class ProductBindingCreatorTest {
 
         Assert.assertNotNull(context.resourceResolver().getResource("/var/commerce/products/testing-english"));
         Assert.assertTrue(true);
+    }
+
+    @Test
+    public void testDeleteBindingWhenConfigurationIsDeleted() {
+        ResourceChange change = new ResourceChange(ResourceChange.ChangeType.REMOVED,
+            "/conf/testing-to-be-deleted/settings/cloudconfigs/commerce", false);
+        creator.onChange(ImmutableList.of(change));
+
+        Assert.assertNull(context.resourceResolver().getResource("/var/commerce/products/testing-to-be-deleted"));
     }
 }

--- a/bundles/cif-virtual-catalog/src/test/resources/context/jcr-catalog-bindings.json
+++ b/bundles/cif-virtual-catalog/src/test/resources/context/jcr-catalog-bindings.json
@@ -1,0 +1,17 @@
+{
+  "products": {
+    "jcr:primaryType": "sling:Folder",
+    "testing-1": {
+      "jcr:primaryType": "sling:Folder",
+      "cq:conf": "/non/existing"
+    },
+    "testing-2": {
+      "jcr:primaryType": "sling:Folder",
+      "cq:conf": "/non/existing/too"
+    },
+    "testing-to-be-deleted": {
+        "jcr:primaryType": "sling:Folder",
+        "cq:conf": "/conf/testing-to-be-deleted"
+    }
+  }
+}

--- a/bundles/cif-virtual-catalog/src/test/resources/context/jcr-conf-page.json
+++ b/bundles/cif-virtual-catalog/src/test/resources/context/jcr-conf-page.json
@@ -1,0 +1,12 @@
+{
+  "cloudconfigs": {
+    "jcr:primaryType": "sling:Folder",
+    "commerce": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "magentoStore": "english"
+      }
+    }
+  }
+}

--- a/bundles/cif-virtual-catalog/src/test/resources/context/jcr-dataroots.json
+++ b/bundles/cif-virtual-catalog/src/test/resources/context/jcr-dataroots.json
@@ -10,6 +10,11 @@
       "jcr:primaryType": "sling:Folder",
       "jcr:title": "Test products no configuration",
       "cq:catalogDataResourceProviderFactory": "non-existent"
+    },
+    "testingWrongConfig": {
+      "jcr:primaryType": "sling:Folder",
+      "jcr:title": "Test products no configuration",
+      "cq:conf": "/conf/wrong-configuration"
     }
 }
 }

--- a/bundles/cif-virtual-catalog/src/test/resources/context/jcr-wrong-conf.json
+++ b/bundles/cif-virtual-catalog/src/test/resources/context/jcr-wrong-conf.json
@@ -1,0 +1,8 @@
+{
+  "cloudconfigs": {
+    "jcr:primaryType": "sling:Folder",
+    "commerce": {
+      "jcr:primaryType": "nt:unstructured"
+    }
+  }
+}

--- a/content/cif-virtual-catalog/pom.xml
+++ b/content/cif-virtual-catalog/pom.xml
@@ -116,6 +116,7 @@
                         <exclude>**/*.xml</exclude>
                         <exclude>**/*.txt</exclude>
                         <exclude>**/*.css</exclude>
+                        <exclude>**/*.config</exclude>
                         <exclude>**/META-INF/**/*</exclude>
                     </excludes>
                 </configuration>

--- a/content/cif-virtual-catalog/src/main/content/META-INF/vault/filter.xml
+++ b/content/cif-virtual-catalog/src/main/content/META-INF/vault/filter.xml
@@ -17,6 +17,7 @@
 <workspaceFilter version="1.0">
     <filter root="/libs/commerce/config">
         <include pattern="/libs/commerce/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-virtual-commerce"/>
+        <include pattern="/libs/commerce/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-default.config"/>
     </filter>
     <filter root="/libs/commerce/install">
         <include pattern="/libs/commerce/install/cq-commerce-virtual-catalog-(.*).jar"/>
@@ -36,4 +37,5 @@
     <filter root="/libs/commerce/gui/content/common/productfield/picker/search/form/tagid-property"/>
     
     <filter root="/oak:index/commerceCqVirtualCatalog" />
+
 </workspaceFilter>

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-default.config
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-default.config
@@ -1,0 +1,9 @@
+scripts=["
+    create service user product-binding-service
+    set ACL on /var/commerce/products
+        allow rep:write for product-binding-service
+    end
+    set ACL on /conf
+        allow jcr:read for product-binding-service
+    end
+"]

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-virtual-commerce.xml
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-virtual-commerce.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OsgiConfig"
           user.default=""
-          user.mapping="[com.adobe.commerce.cif.virtual-catalog:virtual-products-service=configuration-reader-service,com.adobe.commerce.cif.virtual-catalog:frontend=content-reader-service]"/>
+          user.mapping="[com.adobe.commerce.cif.virtual-catalog:virtual-products-service=configuration-reader-service,com.adobe.commerce.cif.virtual-catalog:frontend=content-reader-service,com.adobe.commerce.cif.virtual-catalog:product-binding-service=product-binding-service]"/>

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/gui/components/admin/products/bindproducttreewizard/commerceproviderdatasource/commerceproviderdatasource.jsp
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/gui/components/admin/products/bindproducttreewizard/commerceproviderdatasource/commerceproviderdatasource.jsp
@@ -25,21 +25,27 @@
                 com.adobe.cq.commerce.virtual.catalog.data.CatalogDataResourceProviderManager" %>
 <%@include file="/libs/foundation/global.jsp" %>
 <%
+    DataSource ds;
     // Get data for datasource
-    Map<String, CatalogDataResourceProviderFactory<?>> dataResourceProviderFactories =
-            sling.getService(CatalogDataResourceProviderManager.class).getProviderFactories();
+    CatalogDataResourceProviderManager resourceProviderManager =   sling.getService(CatalogDataResourceProviderManager.class);
+    if (resourceProviderManager == null) {
+        log.warn("CatalogDataResourceProviderManager not found");
+        ds = EmptyDataSource.instance();
+    }  else {
+        Map<String, CatalogDataResourceProviderFactory<?>> dataResourceProviderFactories = resourceProviderManager.getProviderFactories();
 
-    // Build datasource
-    ArrayList<Resource> resourceList = new ArrayList<Resource>();
-    for (String factoryName : dataResourceProviderFactories.keySet()) {
-        Map<String, Object> map = new HashMap<>();
-        map.put("text", factoryName);
-        map.put("value", factoryName);
-        ValueMapResource syntheticResource = new ValueMapResource(resourceResolver, new ResourceMetadata(), "", new ValueMapDecorator(map));
-        resourceList.add(syntheticResource);
+        // Build datasource
+        ArrayList<Resource> resourceList = new ArrayList<Resource>();
+        for (String factoryName : dataResourceProviderFactories.keySet()) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("text", factoryName);
+            map.put("value", factoryName);
+            ValueMapResource syntheticResource = new ValueMapResource(resourceResolver, new ResourceMetadata(), "",
+                    new ValueMapDecorator(map));
+            resourceList.add(syntheticResource);
+        }
+        ds = resourceList.isEmpty() ? EmptyDataSource.instance() : new SimpleDataSource(resourceList.iterator());
     }
-    DataSource ds = resourceList.isEmpty() ? EmptyDataSource.instance() : new SimpleDataSource(resourceList.iterator());
-
     // Put datasource in request for consumption
     request.setAttribute(DataSource.class.getName(), ds);
 %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The product binding creation is handled by a `ResourceChangeListener` that kicks off when a new node is added under `/conf`. The product binding name follows this pattern: `<configuration name>-<store view>`.

The operations are performed using a new service user which has `jcr:read` access on `/conf` and `rep:write` access on `/var/commerce/products`.

**Notes**: 
- deleting the configuration doesn't delete the binding. The listener doesn't handle deletions because of a technical limitation: when a resource is deleted there is absolutely no information regarding the resource itself, just the path. There are ways to determine the properties, using the `VersionManager`, but they are not 100% reliable I think it's more trouble than it's worth.
- the bindings are only created when a configuration is created. For configurations created prior to the upgrade, the bindings must be created manually.

## Related Issue

CIF-1325

## Motivation and Context

Automate configuration of new stores.

## How Has This Been Tested?

Functional tests, unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
