### PR TITLE
CIF-1393 - Automatic product binding creation fails

### DIFF
--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandler.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/omnisearch/ProductsSuggestionOmniSearchHandler.java
@@ -45,6 +45,7 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -73,6 +74,9 @@ public class ProductsSuggestionOmniSearchHandler extends AbstractOmniSearchHandl
     private static final String VIRTUAL_PRODUCT_QUERY_LANGUAGE = "virtualProductOmnisearchQuery";
     private static final String PARAMETER_OFFSET = "_commerce_offset";
     private static final String PARAMETER_LIMIT = "_commerce_limit";
+
+    @Reference(target = "(" + ServiceUserMapped.SUBSERVICENAME + "=omnisearch-service)")
+    private ServiceUserMapped serviceUserMapped;
 
     @Reference
     private ResourceResolverFactory resolverFactory = null;

--- a/bundles/cif-connector-graphql/src/test/resources/test-queries/graphql-requests.log
+++ b/bundles/cif-connector-graphql/src/test/resources/test-queries/graphql-requests.log
@@ -1,10 +1,26 @@
-{categoryList(filters:{url_key:{eq:"meskwielt-Purple-XS"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
+{products(filter:{sku:{eq:"meskwielt"}}){items{__typename,id,sku,name,description{html},image{url},thumbnail{url},url_key,updated_at,created_at,price{regularPrice{amount{currency,value}}},categories{__typename,url_path},... on ConfigurableProduct{variants{product{id,sku,name,description{html},image{url},thumbnail{url},url_key,updated_at,created_at,price{regularPrice{amount{currency,value}}}}}}}}}
+
+{categoryList(filters:{name:{match:"1.2.3.4.5"}}){id,name,url_path,url_key}}
+
+{categoryList(filters:{ids:{eq:"1"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
+
+{category(id:19){products(sort:{name:ASC},currentPage:1,pageSize:10){total_count,items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}}
+
+{categoryList(filters:{url_key:{eq:"venia-dresses"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
+
+{products(filter:{category_id:{eq:"11"},price:{from:""}},sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
+
+{products(search:"coats",sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
 
 {categoryList(filters:{url_key:{eq:"meskwielt"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
 
-{categoryList(filters:{url_key:{eq:"coats"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
+{products(search:"coats",filter:{category_id:{eq:"11"}},sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
 
-{products(filter:{sku:{eq:"meskwielt"}}){items{__typename,id,sku,name,description{html},image{url},thumbnail{url},url_key,updated_at,created_at,price{regularPrice{amount{currency,value}}},categories{__typename,url_path},... on ConfigurableProduct{variants{product{id,sku,name,description{html},image{url},thumbnail{url},url_key,updated_at,created_at,price{regularPrice{amount{currency,value}}}}}}}}}
+{products(filter:{price:{from:""}},sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
+
+{categoryList(filters:{url_key:{eq:"meskwielt-Purple-XS"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
+
+{categoryList(filters:{url_key:{eq:"coats"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
 
 {categoryList(filters:{url_key:{eq:"image"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
 
@@ -16,21 +32,5 @@
 
 {categoryList(filters:{ids:{eq:"4"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
 
-{categoryList(filters:{url_key:{eq:"venia-dresses"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
-
 {category(id:19){products(sort:{name:ASC},currentPage:1,pageSize:20){total_count,items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}}
-
-{categoryList(filters:{name:{match:"1.2.3.4.5"}}){id,name,url_path,url_key}}
-
-{categoryList(filters:{ids:{eq:"1"}}){id,name,url_path,url_key,product_count,children_count,children{id,name,url_path,url_key,product_count,children_count}}}
-
-{category(id:19){products(sort:{name:ASC},currentPage:1,pageSize:10){total_count,items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}}
-
-{products(filter:{category_id:{eq:"11"},price:{from:""}},sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
-
-{products(search:"coats",sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
-
-{products(search:"coats",filter:{category_id:{eq:"11"}},sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
-
-{products(filter:{price:{from:""}},sort:{relevance:DESC},currentPage:0,pageSize:3){items{__typename,id,sku,name,url_key,updated_at,thumbnail{url}}}}
 

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
@@ -45,6 +45,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -102,6 +103,9 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
     private EventListener[] observationEventListeners;
 
     private volatile List<Resource> dataRoots;
+
+    @Reference(target = "(" + ServiceUserMapped.SUBSERVICENAME + "=" + VIRTUAL_PRODUCTS_SERVICE + ")")
+    private ServiceUserMapped serviceUserMapped;
 
     /**
      * Map for holding the virtual catalog data resource provider registrations, with the catalog provider as key and the registration as
@@ -223,6 +227,10 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
             }
             log.debug("Configured provider id is {}", providerId);
             factory = providerFactories.get(providerId);
+            if (factory == null) {
+                log.warn("No factory for provider id {}, nothing to do here", providerId);
+                return false;
+            }
         } else {
 
             if (StringUtils.isBlank(rootPath)) {

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataProviderManagerConfTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataProviderManagerConfTest.java
@@ -26,6 +26,7 @@ import javax.jcr.RepositoryException;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.resourceresolver.MockResourceResolverFactory;
@@ -40,6 +41,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 
 import com.adobe.cq.commerce.virtual.catalog.data.CatalogDataResourceProviderFactory;
 import com.adobe.cq.commerce.virtual.catalog.data.CatalogDataResourceProviderManager;
+import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
 import io.wcm.testing.mock.aem.junit.AemContextBuilder;
 
@@ -90,6 +92,10 @@ public class CatalogDataProviderManagerConfTest {
 
         Map<String, String> properties = factoryConfig.properties;
         context.registerService(CatalogDataResourceProviderFactory.class, factoryConfig.factory, properties);
+
+        ServiceUserMapped serviceUserMapped = Mockito.mock(ServiceUserMapped.class);
+        context.registerService(ServiceUserMapped.class, serviceUserMapped, ImmutableMap.of(ServiceUserMapped.SUBSERVICENAME,
+            "virtual-products-service"));
 
         manager = context.registerInjectActivateService(new CatalogDataResourceProviderManagerImpl());
     }

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
@@ -22,14 +22,17 @@ import javax.jcr.RepositoryException;
 import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.day.cq.wcm.api.WCMException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
 import io.wcm.testing.mock.aem.junit.AemContextBuilder;
 
@@ -43,6 +46,10 @@ public class ProductBindingCreatorTest {
     public void setup() throws ParseException, RepositoryException, IOException {
         context.load().json("/context/jcr-conf-page.json", "/conf/testing/settings");
         context.load().json("/context/jcr-catalog-bindings.json", "/var/commerce");
+
+        ServiceUserMapped serviceUserMapped = Mockito.mock(ServiceUserMapped.class);
+        context.registerService(ServiceUserMapped.class, serviceUserMapped, ImmutableMap.of(ServiceUserMapped.SUBSERVICENAME,
+            "product-binding-service"));
 
         creator = new ProductBindingCreator();
         context.registerInjectActivateService(creator);


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->
Several changes in this PR:
* General change regarding the service users: use the `ServiceUserMapped` marker service to instruct the bundles to wait until the service user become available.
* Product binding creation: call `refresh()` on the resource resolver when processing an addition, so the resolver can have access to the newly created configuration
* Catalog data resource provider manager: skip the data root registration if there's no provider factory for a given provider id. This happens when the demo store is first installed and there is binding and configuration created, but the GraphQL client is not configured yet.

## Related Issue

CIF-1393

## Motivation and Context

Some components fail to activate because the service user mapping is not available at that time.

## How Has This Been Tested?
Functional testing
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
