### PR TITLE
CIF-1446: Preview with Product in page editor - preview URL must conform to UrlProvider configuration

### DIFF
--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
@@ -24,58 +24,52 @@ window.CIF.PagePreview = {};
 
     var relPdpPreview = '.cq-commerce-pdp-preview-activator';
     var relPlpPreview = '.cq-commerce-plp-preview-activator';
+    var productPreviewServletUrl = '/bin/wcm/cif.previewproduct.html';
+    var categoryPreviewServletUrl = '/bin/wcm/cif.previewcategory.html';
 
-    var handlePreview = function(e, data) {
-        if (!data) {
+    var handleProductPreview = function(e, data) {
+        handlePreview(data, productPreviewServletUrl);
+    };
+
+    var handleCategoryPreview = function(e, data) {
+        handlePreview(data, categoryPreviewServletUrl);
+    };
+
+    var handlePreview = function(data, previewServletUrl) {
+        if (!data || ![productPreviewServletUrl, categoryPreviewServletUrl].includes(previewServletUrl)) {
             return;
         }
 
         var selections = data.selections;
-        var productSlug = null;
+        var slugValue = null;
         if (Array.isArray(selections)) {
             if (selections.length > 0 && selections[0]) {
-                productSlug = selections[0].value;
+                slugValue = selections[0].value;
             }
         } else if (selections) {
-            productSlug = selections.value;
+            slugValue = selections.value;
         }
 
-        var url = Granite.author.ContentFrame.location;
-        var previewUrl = createPreviewUrl(url, productSlug);
-
-        if (previewUrl) {
-            window.open(previewUrl);
-        }
-    };
-
-    var createPreviewUrl = function(url, selector) {
-        if (!url || !selector) {
+        // slugValue can be: <id>, <slug>, <path>, <sku>, <sku>#<variant_sku>
+        // depending on picker's selectionId & filter parameters.
+        // However the selection data should contain all available attributes of the selected item
+        var [slug, variantSku] = slugValue ? slugValue.split('#') : [];
+        if (!slug) {
             return null;
         }
 
-        var indLastSlash = url.lastIndexOf('/');
-        if (indLastSlash < 0 || indLastSlash === url.length - 1) {
-            return null;
+        // prepare all possible parameters
+        var params = previewServletUrl === productPreviewServletUrl ? { url_key: slug, sku: slug } : { id: slug };
+        if (variantSku) {
+            params.variant_sku = variantSku;
         }
+        const qs = new URLSearchParams(params);
 
-        var urlPath = url.slice(0, indLastSlash + 1);
-        var urlName = url.substring(indLastSlash + 1);
-        var indHtml = urlName.lastIndexOf('.html');
-        var previewUrl = null;
-        if (indHtml > -1) {
-            var indSelector = urlName.slice(0, indHtml).lastIndexOf('.');
-            if (indSelector > -1) {
-                previewUrl = urlPath + urlName.slice(0, indSelector) + '.' + selector + '.html';
-            } else {
-                previewUrl = urlPath + urlName.slice(0, indHtml) + '.' + selector + '.html';
-            }
-        }
-
-        return previewUrl;
+        window.open(previewServletUrl + '?' + qs.toString());
     };
 
-    Granite.$(document).on('cifProductPickerSelection', relPdpPreview, handlePreview);
-    Granite.$(document).on('cifCategoryPickerSelection', relPlpPreview, handlePreview);
+    Granite.$(document).on('cifProductPickerSelection', relPdpPreview, handleProductPreview);
+    Granite.$(document).on('cifCategoryPickerSelection', relPlpPreview, handleCategoryPreview);
 
-    window.CIF.PagePreview = { handlePreview: handlePreview, createPreviewUrl: createPreviewUrl };
+    window.CIF.PagePreview = { handlePreview: handlePreview };
 })(window, document, Granite);

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
@@ -41,19 +41,19 @@ window.CIF.PagePreview = {};
         }
 
         var selections = data.selections;
-        var slugValue = null;
+        var identifier = null;
         if (Array.isArray(selections)) {
             if (selections.length > 0 && selections[0]) {
-                slugValue = selections[0].value;
+                identifier = selections[0].value;
             }
         } else if (selections) {
-            slugValue = selections.value;
+            identifier = selections.value;
         }
 
-        // slugValue can be: <id>, <slug>, <path>, <sku>, <sku>#<variant_sku>
-        // depending on picker's selectionId & filter parameters.
-        // However the selection data should contain all available attributes of the selected item
-        var [slug, variantSku] = slugValue ? slugValue.split('#') : [];
+        // Currently the picker returns only one identifier for the selected item.
+        // It can be one of the following: <id>, <url_key>, <path>, <sku>, <sku>#<variant_sku>
+        // This needs to be fixed in the future version so the picker will return multiple identifiers
+        var [slug, variantSku] = identifier ? identifier.split('#') : [];
         if (!slug) {
             return null;
         }

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
@@ -51,7 +51,7 @@ window.CIF.PagePreview = {};
         }
 
         // Currently the picker returns only one identifier for the selected item.
-        // It can be one of the following: <id>, <url_key>, <sku>, <sku>#<variant_sku>, <url_key>#<variant_sku>
+        // It can be one of the following: <id>, <url_key>, <sku>, <sku>#<variant_sku>
         // This needs to be fixed in the future version so the picker will return multiple identifiers
         var [itemIdentifier, itemVariant] = identifier ? identifier.split('#') : [];
         if (!itemIdentifier) {

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
@@ -51,17 +51,20 @@ window.CIF.PagePreview = {};
         }
 
         // Currently the picker returns only one identifier for the selected item.
-        // It can be one of the following: <id>, <url_key>, <path>, <sku>, <sku>#<variant_sku>
+        // It can be one of the following: <id>, <url_key>, <sku>, <sku>#<variant_sku>, <url_key>#<variant_sku>
         // This needs to be fixed in the future version so the picker will return multiple identifiers
-        var [slug, variantSku] = identifier ? identifier.split('#') : [];
-        if (!slug) {
+        var [itemIdentifier, itemVariant] = identifier ? identifier.split('#') : [];
+        if (!itemIdentifier) {
             return null;
         }
 
         // prepare all possible parameters
-        var params = previewServletUrl === productPreviewServletUrl ? { url_key: slug, sku: slug } : { id: slug };
-        if (variantSku) {
-            params.variant_sku = variantSku;
+        var params =
+            previewServletUrl === productPreviewServletUrl
+                ? { url_key: itemIdentifier, sku: itemIdentifier }
+                : { id: itemIdentifier };
+        if (itemVariant) {
+            params.variant_sku = itemVariant;
         }
         const qs = new URLSearchParams(params);
 

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/authoring/editor/pagepreview/clientlibs/pagepreview.js
@@ -36,7 +36,7 @@ window.CIF.PagePreview = {};
     };
 
     var handlePreview = function(data, previewServletUrl) {
-        if (!data || ![productPreviewServletUrl, categoryPreviewServletUrl].includes(previewServletUrl)) {
+        if (!data) {
             return;
         }
 
@@ -71,5 +71,8 @@ window.CIF.PagePreview = {};
     Granite.$(document).on('cifProductPickerSelection', relPdpPreview, handleProductPreview);
     Granite.$(document).on('cifCategoryPickerSelection', relPlpPreview, handleCategoryPreview);
 
-    window.CIF.PagePreview = { handlePreview: handlePreview };
+    window.CIF.PagePreview = {
+        handleProductPreview: handleProductPreview,
+        handleCategoryPreview: handleCategoryPreview
+    };
 })(window, document, Granite);

--- a/content/cif-connector/tests/src/libs/commerce/gui/components/authoring/editor/pagepreview/PagePreviewTest.js
+++ b/content/cif-connector/tests/src/libs/commerce/gui/components/authoring/editor/pagepreview/PagePreviewTest.js
@@ -41,17 +41,27 @@ describe('PagePreview', () => {
 
         sinon.spy(window, 'open');
 
-        handleProductPreview(null, { selections: { value: 'slug' } });
-        assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug'));
+        handleProductPreview(null, { selections: { value: 'item-identifier' } });
+        assert.isTrue(
+            window.open.calledWith(productPreviewServletUrl + '?url_key=item-identifier&sku=item-identifier')
+        );
 
-        handleProductPreview(null, { selections: { value: 'slug#variant' } });
-        assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug&variant_sku=variant'));
+        handleProductPreview(null, { selections: { value: 'item-identifier#item-variant' } });
+        assert.isTrue(
+            window.open.calledWith(
+                productPreviewServletUrl + '?url_key=item-identifier&sku=item-identifier&variant_sku=item-variant'
+            )
+        );
 
-        handleProductPreview(null, { selections: [{ value: 'slug' }] });
-        assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug'));
+        handleProductPreview(null, { selections: [{ value: 'item-identifier' }] });
+        assert.isTrue(
+            window.open.calledWith(productPreviewServletUrl + '?url_key=item-identifier&sku=item-identifier')
+        );
 
-        handleProductPreview(null, { selections: [{ value: 'slug' }, { value: 'slug2' }] });
-        assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug'));
+        handleProductPreview(null, { selections: [{ value: 'item-identifier' }, { value: 'item-identifier-2' }] });
+        assert.isTrue(
+            window.open.calledWith(productPreviewServletUrl + '?url_key=item-identifier&sku=item-identifier')
+        );
 
         window.open.restore();
     });
@@ -61,14 +71,14 @@ describe('PagePreview', () => {
 
         sinon.spy(window, 'open');
 
-        handleCategoryPreview(null, { selections: { value: 'slug' } });
-        assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=slug'));
+        handleCategoryPreview(null, { selections: { value: 'item-identifier' } });
+        assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=item-identifier'));
 
-        handleCategoryPreview(null, { selections: [{ value: 'slug' }] });
-        assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=slug'));
+        handleCategoryPreview(null, { selections: [{ value: 'item-identifier' }] });
+        assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=item-identifier'));
 
-        handleCategoryPreview(null, { selections: [{ value: 'slug' }, { value: 'slug2' }] });
-        assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=slug'));
+        handleCategoryPreview(null, { selections: [{ value: 'item-identifier' }, { value: 'item-identifier-2' }] });
+        assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=item-identifier'));
 
         window.open.restore();
     });

--- a/content/cif-connector/tests/src/libs/commerce/gui/components/authoring/editor/pagepreview/PagePreviewTest.js
+++ b/content/cif-connector/tests/src/libs/commerce/gui/components/authoring/editor/pagepreview/PagePreviewTest.js
@@ -17,10 +17,8 @@
 describe('PagePreview', () => {
     var handleProductPreview = window.CIF.PagePreview.handleProductPreview;
     var handleCategoryPreview = window.CIF.PagePreview.handleCategoryPreview;
-    var productPreviewServletUrl = '/bin/wcm/cif.previewproduct.html';
-    var categoryPreviewServletUrl = '/bin/wcm/cif.previewcategory.html';
 
-    it('handlePreview() does nothing for invalid selections or invalid preview Urls', () => {
+    it('Handling preview does nothing for invalid selections', () => {
         sinon.spy(window, 'open');
 
         handleProductPreview(null, null);
@@ -39,7 +37,7 @@ describe('PagePreview', () => {
     });
 
     it('handleProductPreview() opens product page preview for the first selection', () => {
-        var handleProductPreview = window.CIF.PagePreview.handleProductPreview;
+        var productPreviewServletUrl = '/bin/wcm/cif.previewproduct.html';
 
         sinon.spy(window, 'open');
 
@@ -59,6 +57,8 @@ describe('PagePreview', () => {
     });
 
     it('handleCategoryPreview() opens category page preview for the first selection', () => {
+        var categoryPreviewServletUrl = '/bin/wcm/cif.previewcategory.html';
+
         sinon.spy(window, 'open');
 
         handleCategoryPreview(null, { selections: { value: 'slug' } });

--- a/content/cif-connector/tests/src/libs/commerce/gui/components/authoring/editor/pagepreview/PagePreviewTest.js
+++ b/content/cif-connector/tests/src/libs/commerce/gui/components/authoring/editor/pagepreview/PagePreviewTest.js
@@ -15,59 +15,59 @@
 'use strict';
 
 describe('PagePreview', () => {
-    var handlePreview = window.CIF.PagePreview.handlePreview;
+    var handleProductPreview = window.CIF.PagePreview.handleProductPreview;
+    var handleCategoryPreview = window.CIF.PagePreview.handleCategoryPreview;
     var productPreviewServletUrl = '/bin/wcm/cif.previewproduct.html';
     var categoryPreviewServletUrl = '/bin/wcm/cif.previewcategory.html';
 
     it('handlePreview() does nothing for invalid selections or invalid preview Urls', () => {
         sinon.spy(window, 'open');
 
-        handlePreview(null, productPreviewServletUrl);
+        handleProductPreview(null, null);
         assert.isFalse(window.open.calledOnce);
 
-        handlePreview({}, productPreviewServletUrl);
+        handleProductPreview(null, {});
         assert.isFalse(window.open.calledOnce);
 
-        handlePreview({ selections: [] }, productPreviewServletUrl);
+        handleProductPreview(null, { selections: [] });
         assert.isFalse(window.open.calledOnce);
 
-        handlePreview({ selections: 'any' }, categoryPreviewServletUrl);
-        assert.isFalse(window.open.calledOnce);
-
-        handlePreview({ selections: { value: 'slug' } }, 'invalidPreviewUrl');
+        handleCategoryPreview(null, { selections: 'any' });
         assert.isFalse(window.open.calledOnce);
 
         window.open.restore();
     });
 
-    it('handlePreview() opens product page preview for the first selection', () => {
+    it('handleProductPreview() opens product page preview for the first selection', () => {
+        var handleProductPreview = window.CIF.PagePreview.handleProductPreview;
+
         sinon.spy(window, 'open');
 
-        handlePreview({ selections: { value: 'slug' } }, productPreviewServletUrl);
+        handleProductPreview(null, { selections: { value: 'slug' } });
         assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug'));
 
-        handlePreview({ selections: { value: 'slug#variant' } }, productPreviewServletUrl);
+        handleProductPreview(null, { selections: { value: 'slug#variant' } });
         assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug&variant_sku=variant'));
 
-        handlePreview({ selections: [{ value: 'slug' }] }, productPreviewServletUrl);
+        handleProductPreview(null, { selections: [{ value: 'slug' }] });
         assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug'));
 
-        handlePreview({ selections: [{ value: 'slug' }, { value: 'slug2' }] }, productPreviewServletUrl);
+        handleProductPreview(null, { selections: [{ value: 'slug' }, { value: 'slug2' }] });
         assert.isTrue(window.open.calledWith(productPreviewServletUrl + '?url_key=slug&sku=slug'));
 
         window.open.restore();
     });
 
-    it('handlePreview() opens category page preview for the first selection', () => {
+    it('handleCategoryPreview() opens category page preview for the first selection', () => {
         sinon.spy(window, 'open');
 
-        handlePreview({ selections: { value: 'slug' } }, categoryPreviewServletUrl);
+        handleCategoryPreview(null, { selections: { value: 'slug' } });
         assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=slug'));
 
-        handlePreview({ selections: [{ value: 'slug' }] }, categoryPreviewServletUrl);
+        handleCategoryPreview(null, { selections: [{ value: 'slug' }] });
         assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=slug'));
 
-        handlePreview({ selections: [{ value: 'slug' }, { value: 'slug2' }] }, categoryPreviewServletUrl);
+        handleCategoryPreview(null, { selections: [{ value: 'slug' }, { value: 'slug2' }] });
         assert.isTrue(window.open.calledWith(categoryPreviewServletUrl + '?id=slug'));
 
         window.open.restore();

--- a/content/cif-connector/tests/src/libs/commerce/gui/components/common/cifpicker/CifPickerTest.js
+++ b/content/cif-connector/tests/src/libs/commerce/gui/components/common/cifpicker/CifPickerTest.js
@@ -22,8 +22,14 @@ describe('CifPicker', () => {
     var getState;
 
     before(() => {
+        var promise = {
+            then: f => {
+                f('elem');
+                return promise;
+            }
+        };
         dollar.ajax = function(asd) {
-            return Promise.resolve(asd);
+            return promise;
         };
         getState = window.CIF.CifPicker.getState;
     });

--- a/content/cif-connector/tests/src/libs/commerce/gui/components/common/cifpicker/CifPickerTest.js
+++ b/content/cif-connector/tests/src/libs/commerce/gui/components/common/cifpicker/CifPickerTest.js
@@ -171,6 +171,30 @@ describe('CifPicker', () => {
         assert.isTrue(callbackSpy.calledOnce);
     });
 
+    it('show picker and call selection handler', () => {
+        var show = window.CIF.CifPicker.show;
+        var state = getState(control);
+        state.api = {
+            attach: function() {},
+            detach: function() {},
+            pick: function() {
+                return {
+                    then: function(resolve, reject) {
+                        resolve();
+                    }
+                };
+            }
+        };
+
+        state.el = { focus: function() {} };
+
+        var selectionHandler = function() {};
+        var selectionHandlerSpy = sinon.spy(selectionHandler);
+
+        show(control, state, selectionHandlerSpy);
+        assert.isTrue(selectionHandlerSpy.calledOnce);
+    });
+
     function verifyCall(url) {
         assert.isTrue(dollar.ajax.calledOnce);
         assert.equal(url, dollar.ajax.getCall(0).args[0].url);


### PR DESCRIPTION
Use `PreviewServlet` from cif-core-components to prepare and redirect to preview Url.

This PR is used in conjunction with https://github.com/adobe/aem-core-cif-components/pull/305

## Description

The preview with product / category now uses the `PreviewServlet` to construct the preview Url based on `UrlProvider` configuration. The servlet will also do a redirect to the preview Url.

The preview servlet url is `/bin/wcm/cif.PREVIEW_SELECTOR.html` where `PREVIEW_SELECTOR` is:

- `previewproduct` - for Product preview
- `previewcategory` - for Category preview

## Related Issue

https://github.com/adobe/aem-core-cif-components/pull/305

## Motivation and Context

Current implementation does not satisfy custom UrlProvider templates.

## How Has This Been Tested?

- unit testing
- manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
