### PR TITLE
CIF-1404 - Editing support for cq:catalogPath

### DIFF
--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/common/FieldInitializerTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/common/FieldInitializerTest.java
@@ -15,6 +15,7 @@
 package com.adobe.cq.commerce.gui.components.common;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import javax.script.SimpleBindings;
 
@@ -26,6 +27,8 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.api.wrappers.ModifiableValueMapDecorator;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.junit.Before;
 
 import com.adobe.cq.commerce.api.conf.CommerceBasePathsService;
@@ -46,6 +49,7 @@ public class FieldInitializerTest {
     protected SimpleBindings bindings = new SimpleBindings();
     protected Resource includedResourceSample;
     protected ModifiableValueMapDecorator valueMap;
+    protected Resource contentResource;
     protected ValueMap contentResourceProperties;
     protected SlingHttpServletRequest request;
     protected RequestPathInfo requestPathInfo;
@@ -79,9 +83,16 @@ public class FieldInitializerTest {
         when(resourceResolver.adaptTo(PageManager.class)).thenReturn(pageManager);
         Page page = mock(Page.class);
         when(pageManager.getContainingPage(anyString())).thenReturn(page);
-        Resource contentResource = mock(Resource.class);
+        contentResource = mock(Resource.class);
         contentResourceProperties = new ModifiableValueMapDecorator(new HashMap<>());
         when(contentResource.getValueMap()).thenReturn(contentResourceProperties);
         when(page.getContentResource()).thenReturn(contentResource);
+    }
+
+    protected void setupContextAwareConfiguration(Map<String, Object> properties) {
+        ConfigurationBuilder configurationBuilder = mock(ConfigurationBuilder.class);
+        when(contentResource.adaptTo(ConfigurationBuilder.class)).thenReturn(configurationBuilder);
+        when(configurationBuilder.name("cloudconfigs/commerce")).thenReturn(configurationBuilder);
+        when(configurationBuilder.asValueMap()).thenReturn(new ValueMapDecorator(properties));
     }
 }

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/common/cifcategoryfield/InitializerTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/common/cifcategoryfield/InitializerTest.java
@@ -14,6 +14,9 @@
 
 package com.adobe.cq.commerce.gui.components.common.cifcategoryfield;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.sling.api.resource.ValueMap;
 import org.junit.Test;
 
@@ -49,14 +52,8 @@ public class InitializerTest extends FieldInitializerTest {
         assertEquals(pickerSrc, properties.get("pickerSrc", String.class));
     }
 
-    @Test
-    public void testCatalogPathForComponentDialog() {
-        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALIG_URI_MARKER);
-        when(requestPathInfo.getSuffix()).thenReturn("component/path");
-        contentResourceProperties.put("cq:catalogPath", "catalog/path");
-
+    private void testRootPath() {
         initializer.init(bindings);
-
         assertNotNull(includedResourceSample);
         ValueMap properties = includedResourceSample.getValueMap();
         assertNotNull(properties);
@@ -64,16 +61,40 @@ public class InitializerTest extends FieldInitializerTest {
     }
 
     @Test
+    public void testCatalogPathForComponentDialog() {
+        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALOG_URI_MARKER);
+        when(requestPathInfo.getSuffix()).thenReturn("component/path");
+        contentResourceProperties.put(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+        testRootPath();
+    }
+
+    @Test
     public void testCatalogPathForPageProperties() {
         when(request.getRequestURI()).thenReturn(CatalogSearchSupport.PAGE_PROPERTIES_URI_MARKER);
         when(request.getParameter("item")).thenReturn("component/path");
         contentResourceProperties.put(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+        testRootPath();
+    }
 
-        initializer.init(bindings);
+    @Test
+    public void testContextAwareConfiguration() {
+        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALOG_URI_MARKER);
+        when(requestPathInfo.getSuffix()).thenReturn("component/path");
+        Map<String, Object> map = Collections.singletonMap(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+        setupContextAwareConfiguration(map);
+        testRootPath();
+    }
 
-        assertNotNull(includedResourceSample);
-        ValueMap properties = includedResourceSample.getValueMap();
-        assertNotNull(properties);
-        assertEquals("catalog/path", properties.get("rootPath", String.class));
+    @Test
+    public void testContextAwareConfigurationWithoutCatalogPath() {
+        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALOG_URI_MARKER);
+        when(requestPathInfo.getSuffix()).thenReturn("component/path");
+
+        // The implementation will fallback to the "old" way of getting the property
+        Map<String, Object> map = Collections.emptyMap();
+        contentResourceProperties.put(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+
+        setupContextAwareConfiguration(map);
+        testRootPath();
     }
 }

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/common/cifproductfield/InitializerTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/gui/components/common/cifproductfield/InitializerTest.java
@@ -14,6 +14,9 @@
 
 package com.adobe.cq.commerce.gui.components.common.cifproductfield;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.sling.api.resource.ValueMap;
 import org.junit.Test;
 
@@ -108,14 +111,8 @@ public class InitializerTest extends FieldInitializerTest {
 
     }
 
-    @Test
-    public void testCatalogPathForComponentDialog() {
-        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALIG_URI_MARKER);
-        when(requestPathInfo.getSuffix()).thenReturn("component/path");
-        contentResourceProperties.put(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
-
+    private void testRootPath() {
         initializer.init(bindings);
-
         assertNotNull(includedResourceSample);
         ValueMap properties = includedResourceSample.getValueMap();
         assertNotNull(properties);
@@ -123,16 +120,27 @@ public class InitializerTest extends FieldInitializerTest {
     }
 
     @Test
+    public void testCatalogPathForComponentDialog() {
+        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALOG_URI_MARKER);
+        when(requestPathInfo.getSuffix()).thenReturn("component/path");
+        contentResourceProperties.put(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+        testRootPath();
+    }
+
+    @Test
     public void testCatalogPathForPageProperties() {
         when(request.getRequestURI()).thenReturn(CatalogSearchSupport.PAGE_PROPERTIES_URI_MARKER);
         when(request.getParameter("item")).thenReturn("component/path");
         contentResourceProperties.put(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+        testRootPath();
+    }
 
-        initializer.init(bindings);
-
-        assertNotNull(includedResourceSample);
-        ValueMap properties = includedResourceSample.getValueMap();
-        assertNotNull(properties);
-        assertEquals("catalog/path", properties.get("rootPath", String.class));
+    @Test
+    public void testContextAwareConfiguration() {
+        when(request.getRequestURI()).thenReturn(CatalogSearchSupport.COMPONENT_DIALOG_URI_MARKER);
+        when(requestPathInfo.getSuffix()).thenReturn("component/path");
+        Map<String, Object> map = Collections.singletonMap(CatalogSearchSupport.PN_CATALOG_PATH, "catalog/path");
+        setupContextAwareConfiguration(map);
+        testRootPath();
     }
 }

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/Constants.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/Constants.java
@@ -22,25 +22,26 @@ import org.apache.commons.lang3.StringUtils;
  */
 public abstract class Constants {
 
-    public static String CONF_ROOT = "/conf";
+    public static final String CONF_ROOT = "/conf";
 
-    public static String CONF_CONTAINER_BUCKET_NAME = "settings";
+    public static final String CONF_CONTAINER_BUCKET_NAME = "settings";
 
-    public static String CLOUDCONFIGS_BUCKET_NAME = "cloudconfigs";
+    public static final String CLOUDCONFIGS_BUCKET_NAME = "cloudconfigs";
 
-    public static String COMMERCE_CONFIG_NAME = "commerce";
+    public static final String COMMERCE_CONFIG_NAME = "commerce";
 
-    public static String COMMERCE_BUCKET_PATH = StringUtils.join(new String[] { CONF_CONTAINER_BUCKET_NAME, CLOUDCONFIGS_BUCKET_NAME,
+    public static final String COMMERCE_BUCKET_PATH = StringUtils.join(new String[] { CONF_CONTAINER_BUCKET_NAME, CLOUDCONFIGS_BUCKET_NAME,
         COMMERCE_CONFIG_NAME }, "/");
 
-    public static String CONFIGURATION_NAME = StringUtils.join(new String[] { CLOUDCONFIGS_BUCKET_NAME, COMMERCE_CONFIG_NAME }, "/");
+    public static final String CONFIGURATION_NAME = StringUtils.join(new String[] { CLOUDCONFIGS_BUCKET_NAME, COMMERCE_CONFIG_NAME }, "/");
 
-    public static String PN_CONF = "cq:conf";
-    public static String PN_MAGENTO_ROOT_CATEGORY_ID = "magentoRootCategoryId";
-    public static String PN_CATALOG_PROVIDER_FACTORY = "cq:catalogDataResourceProviderFactory";
+    public static final String PN_CONF = "cq:conf";
+    public static final String PN_MAGENTO_ROOT_CATEGORY_ID = "magentoRootCategoryId";
+    public static final String PN_CATALOG_PROVIDER_FACTORY = "cq:catalogDataResourceProviderFactory";
     public static final String PN_CATALOG_IDENTIFIER = "cq:catalogIdentifier";
     public static final String PN_GRAPHQL_CLIENT = "cq:graphqlClient";
     public static final String PN_MAGENTO_STORE = "magentoStore";
+    public static final String PN_CATALOG_PATH = "cq:catalogPath";
 
     private Constants() {
 

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreator.java
@@ -29,6 +29,7 @@ import javax.jcr.Session;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -176,8 +177,15 @@ public class ProductBindingCreator implements ResourceChangeListener {
         LOG.debug("Check if we already have a binding at {}", bindingPath);
 
         try {
-            LOG.debug("Creating a new resource at {}", parent.getPath() + "/" + bindingName);
+            LOG.debug("Creating a new resource at {}", bindingPath);
             ResourceUtil.getOrCreateResource(resolver, bindingPath, mappingProperties, "", true);
+
+            if (contentResource != null) {
+                LOG.debug("Adding {} property at {}", Constants.PN_CATALOG_PATH, contentResource.getPath());
+                ModifiableValueMap map = contentResource.adaptTo(ModifiableValueMap.class);
+                map.put(Constants.PN_CATALOG_PATH, bindingPath);
+                resolver.commit();
+            }
         } catch (PersistenceException e) {
             LOG.error(e.getMessage(), e);
         }

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/ProductBindingCreatorTest.java
@@ -21,6 +21,7 @@ import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.observation.ResourceChange;
 import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -64,7 +65,10 @@ public class ProductBindingCreatorTest {
         creator.onChange(ImmutableList.of(change));
 
         Assert.assertNotNull(context.resourceResolver().getResource("/var/commerce/products/testing-english"));
-        Assert.assertTrue(true);
+
+        // Test that the cq:catalogPath property was added to the configuration
+        Resource config = context.resourceResolver().getResource("/conf/testing/settings/cloudconfigs/commerce/jcr:content");
+        Assert.assertEquals("/var/commerce/products/testing-english", config.getValueMap().get("cq:catalogPath"));
     }
 
     @Test

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-default.config
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/libs/commerce/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-default.config
@@ -5,5 +5,6 @@ scripts=["
     end
     set ACL on /conf
         allow jcr:read for product-binding-service
+        allow jcr:modifyProperties for product-binding-service
     end
 "]


### PR DESCRIPTION
- create cq:catalogPath property in /conf when the binding is automatically created
- lookup cq:catalogPath property in /conf in pickers

## How Has This Been Tested?

Extended unit tests and manually tested.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
