### PR TITLE
CIF-1162 - Pickers opened for page preview should honor cq:catalogPath

### DIFF
--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/renderconditions/IsProductDetailPageServlet.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/renderconditions/IsProductDetailPageServlet.java
@@ -107,7 +107,7 @@ public class IsProductDetailPageServlet extends SlingSafeMethodsServlet {
     }
 
     /**
-     * Finds the the {@code cq:catalogPath} property at the given path and exposes its value in the property
+     * Finds the {@code cq:catalogPath} property at the given path and exposes its value in the property
      * {@link #CATALOG_PATH_PROPERTY} to Granite UI expressions.
      *
      * @param path a Sling resource path

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/renderconditions/IsProductDetailPageServlet.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/renderconditions/IsProductDetailPageServlet.java
@@ -27,7 +27,10 @@ import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.osgi.service.component.annotations.Component;
 
+import com.adobe.cq.commerce.api.conf.CommerceBasePathsService;
+import com.adobe.cq.commerce.graphql.search.CatalogSearchSupport;
 import com.adobe.granite.ui.components.Config;
+import com.adobe.granite.ui.components.ExpressionCustomizer;
 import com.adobe.granite.ui.components.ExpressionHelper;
 import com.adobe.granite.ui.components.ExpressionResolver;
 import com.adobe.granite.ui.components.rendercondition.RenderCondition;
@@ -46,6 +49,7 @@ import com.day.cq.wcm.api.PageManager;
 public class IsProductDetailPageServlet extends SlingSafeMethodsServlet {
 
     static final String PRODUCT_RT = "core/cif/components/commerce/product/v1/product";
+    static final String CATALOG_PATH_PROPERTY = "catalogPath";
 
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) {
         final Config cfg = new Config(request.getResource());
@@ -54,6 +58,9 @@ public class IsProductDetailPageServlet extends SlingSafeMethodsServlet {
         final String path = ex.getString(cfg.get("path", String.class));
         boolean decision = isProductDetailPage(path, request.getResourceResolver());
         request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(decision));
+        if (decision) {
+            prepareCatalogPathProperty(path, request);
+        }
     }
 
     private boolean isProductDetailPage(String path, ResourceResolver resourceResolver) {
@@ -97,5 +104,24 @@ public class IsProductDetailPageServlet extends SlingSafeMethodsServlet {
         }
 
         return false;
+    }
+
+    /**
+     * Finds the the {@code cq:catalogPath} property at the given path and exposes its value in the property
+     * {@link #CATALOG_PATH_PROPERTY} to Granite UI expressions.
+     *
+     * @param path a Sling resource path
+     * @param request the current request
+     */
+    static void prepareCatalogPathProperty(String path, SlingHttpServletRequest request) {
+        ResourceResolver resourceResolver = request.getResourceResolver();
+        CatalogSearchSupport catalogSearchSupport = new CatalogSearchSupport(resourceResolver);
+        String catalogPath = catalogSearchSupport.findCatalogPath(path);
+        if (StringUtils.isBlank(catalogPath)) {
+            CommerceBasePathsService pathsService = resourceResolver.adaptTo(CommerceBasePathsService.class);
+            catalogPath = pathsService.getProductsBasePath();
+        }
+        ExpressionCustomizer customizer = ExpressionCustomizer.from(request);
+        customizer.setVariable(CATALOG_PATH_PROPERTY, catalogPath);
     }
 }

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/renderconditions/IsProductListPageServlet.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/renderconditions/IsProductListPageServlet.java
@@ -36,6 +36,7 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 
 import static com.adobe.cq.commerce.renderconditions.IsProductDetailPageServlet.containsComponent;
+import static com.adobe.cq.commerce.renderconditions.IsProductDetailPageServlet.prepareCatalogPathProperty;
 
 @Component(
     service = Servlet.class,
@@ -56,6 +57,9 @@ public class IsProductListPageServlet extends SlingSafeMethodsServlet {
         final String path = ex.getString(cfg.get("path", String.class));
         boolean decision = isProductListPage(path, request.getResourceResolver());
         request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(decision));
+        if (decision) {
+            prepareCatalogPathProperty(path, request);
+        }
     }
 
     private boolean isProductListPage(String path, ResourceResolver resourceResolver) {

--- a/content/cif-connector/src/main/content/jcr_root/libs/wcm/core/content/editor/_jcr_content/content/items/content.xml
+++ b/content/cif-connector/src/main/content/jcr_root/libs/wcm/core/content/editor/_jcr_content/content/items/content.xml
@@ -17,6 +17,7 @@
                                         text="View with Product">
                                         <granite:data
                                             jcr:primaryType="nt:unstructured"
+                                            root="${catalogPath}"
                                             selectionid="slug"/>
                                         <granite:rendercondition
                                             jcr:primaryType="nt:unstructured"
@@ -31,6 +32,7 @@
                                             text="View with Category">
                                         <granite:data
                                                 jcr:primaryType="nt:unstructured"
+                                                root="${catalogPath}"
                                                 selectionid="id"/>
                                         <granite:rendercondition
                                                 jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
 * apply cq:catalogPath to product and category picker of PDP and PLP preview actions

## Description

When the PDP preview and PLP preview actions open product picker and category picker these pickers should respect the cq:catalogPath property for the site and open with root path defined by this property.

## Related Issue

CIF-1162

## How Has This Been Tested?

With JUnit and, manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
