### PR TITLE
CIF-1544 - IT for 6.4.6 fails because of product-binding-service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,11 +105,11 @@ jobs:
     <<: *integration_test_steps
 
 
-  integration-test-646:
+  integration-test-648:
     docker:
       - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.4-jdk8
         <<: *docker_auth
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem:6.4.6
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem:6.4.8
         <<: *docker_auth
     resource_class: large
     working_directory: /home/circleci/build
@@ -153,7 +153,7 @@ workflows:
           requires:
             - build
             - karma
-      - integration-test-646:
+      - integration-test-648:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.5
+  codecov: codecov/codecov@1.1.1
 
 common:
   restore_cache: &restore_cache
@@ -66,7 +66,6 @@ jobs:
       - store_artifacts:
           path: test-results/junit
       - codecov/upload:
-          conf: .circleci/codecov.yml
           flags: unittests
 
   karma:
@@ -90,15 +89,14 @@ jobs:
       - store_artifacts:
           path: content/cif-connector/tests/karma-junit
       - codecov/upload:
-          conf: .circleci/codecov.yml
           flags: karma
 
 
-  integration-test-652:
+  integration-test-655:
     docker:
       - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-qp:6.4.4-jdk11
         <<: *docker_auth
-      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem:6.5.2
+      - image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem:6.5.5
         <<: *docker_auth
     resource_class: large
     working_directory: /home/circleci/build
@@ -146,7 +144,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - integration-test-652:
+      - integration-test-655:
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
- upgrade to service pack 6.4.8

While there is an issue with the `product-binding-service`, this was not the root cause of the IT failure. I think there was rather an issue with the docker image, so I rebuilt it with the latest AEM service pack.