### PR TITLE
CIF-1713 - [CIF Connector] Add support for urlPath property in catego…

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The category picker field supports the following optional properties:
 * `rootPath` - configure the root path of the virtual catalog data tree to be used (default = `/var/commerce/products`)
 * `multiple` (true, false) - allows to select one or multiple categories (default = false)
 * `emptyText` - to configure the empty text value of the picker field
-* `selectionId`(id, path, sku, slug) - allows to choose the category attribute to be returned by the picker (default = id)
+* `selectionId`(id, path, idAndUrlPath) - allows to choose the category attribute to be returned by the picker (default = id). The `idAndUrlPath` is a special option that will store the category `id` and Magento's `url_path` separated by a `|` character like for example `1|men/tops`.
 
 The `cifcategoryfield` component requires the `cif.shell.picker` clientlib. To add a clientlib to a dialog, you can use the `extraClientlibs` property. See also [Customizing Dialog Fields
 ](https://docs.adobe.com/content/help/en/experience-manager-65/developing/components/developing-components.html#customizing-dialog-fields).

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/CategoryResource.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/CategoryResource.java
@@ -33,6 +33,7 @@ import static com.adobe.cq.commerce.graphql.resource.Constants.CATEGORY;
 import static com.adobe.cq.commerce.graphql.resource.Constants.CIF_ID;
 import static com.adobe.cq.commerce.graphql.resource.Constants.LEAF_CATEGORY;
 import static com.adobe.cq.commerce.graphql.resource.Constants.MAGENTO_GRAPHQL_PROVIDER;
+import static com.adobe.cq.commerce.graphql.resource.Constants.URL_PATH;
 
 class CategoryResource extends SyntheticResource {
 
@@ -56,6 +57,7 @@ class CategoryResource extends SyntheticResource {
         if (category != null) {
             map.put(JcrConstants.JCR_TITLE, category.getName());
             map.put(CIF_ID, category.getId());
+            map.put(URL_PATH, category.getUrlPath());
             String str = category.getChildrenCount();
             int childCount = 0;
             try {

--- a/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/Constants.java
+++ b/bundles/cif-connector-graphql/src/main/java/com/adobe/cq/commerce/graphql/resource/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
     public static final String SKU = "sku";
     public static final String SLUG = "slug";
     public static final String CIF_ID = "cifId";
+    public static final String URL_PATH = "urlPath";
     public static final String PRODUCT_FORMATTED_PRICE = "formattedPrice";
     public static final String STORE_HEADER = "Store";
     public static final String MAGENTO_STORE_PROPERTY = PN_MAGENTO_STORE;

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -68,6 +68,7 @@ import static com.adobe.cq.commerce.graphql.resource.Constants.IS_ERROR;
 import static com.adobe.cq.commerce.graphql.resource.Constants.LEAF_CATEGORY;
 import static com.adobe.cq.commerce.graphql.resource.Constants.MAGENTO_GRAPHQL_PROVIDER;
 import static com.adobe.cq.commerce.graphql.resource.Constants.PRODUCT;
+import static com.adobe.cq.commerce.graphql.resource.Constants.URL_PATH;
 import static com.adobe.cq.commerce.graphql.resource.GraphqlQueryLanguageProvider.VIRTUAL_PRODUCT_QUERY_LANGUAGE;
 import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
 import static org.junit.Assert.assertEquals;
@@ -213,6 +214,8 @@ public class GraphqlResourceProviderTest {
                 // deep read cifId
                 String cifId = category.getValueMap().get(CIF_ID, String.class);
                 assertEquals(cifId, category.getValueMap().get("./" + CIF_ID, String.class));
+
+                assertEquals("venia-dresses", category.getValueMap().get(URL_PATH, String.class));
             }
         }
     }

--- a/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifcategoryfield/CIFCategoryFieldHelper.java
+++ b/content/cif-connector/src/main/content/jcr_root/libs/commerce/gui/components/common/cifcategoryfield/CIFCategoryFieldHelper.java
@@ -36,7 +36,7 @@ public class CIFCategoryFieldHelper extends WCMUsePojo {
         }
 
         String st = getRequest().getParameter("selectionId");
-        if ("id".equals(st) || "path".equals(st)) {
+        if ("id".equals(st) || "path".equals(st) || "idAndUrlPath".contentEquals(st)) {
             selectionId = st;
         } else {
             selectionId = "id";
@@ -83,8 +83,10 @@ public class CIFCategoryFieldHelper extends WCMUsePojo {
     public String getSelectionId() {
         if ("id".equals(selectionId)) {
             return getProperties().get("cifId", String.class);
-        } else if ("path".equals(selectionId)){
+        } else if ("path".equals(selectionId)) {
             return getResource().getPath();
+        } else if ("idAndUrlPath".equals(selectionId)) {
+            return getProperties().get("cifId", String.class) + "|" + getProperties().get("urlPath", String.class);
         } else {
             return getProperties().get("cifId", String.class);
         }


### PR DESCRIPTION
…ry picker

- add new `idAndUrlPath` selection type in picker

## Description

Adds the `idAndUrlPath` to select both the category `id` and `url_path` in the category picker. For example, the picker would return something like `12|men/tops`.

This will be processed in https://github.com/adobe/aem-core-cif-components/pull/429

## How Has This Been Tested?

Unit tested and manually tested.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
