### PR TITLE
CIF-1715: Cancel button issue in folder properties and configuration properties

### DIFF
--- a/content/cif-virtual-catalog/src/main/content/META-INF/vault/filter.xml
+++ b/content/cif-virtual-catalog/src/main/content/META-INF/vault/filter.xml
@@ -31,7 +31,8 @@
     <filter root="/libs/commerce/gui/components/admin/products/childrow/childrow.jsp"/>
     <filter root="/libs/commerce/gui/components/admin/products/childcolumnitem/childcolumnitem.jsp"/>
     <filter root="/libs/commerce/gui/components/admin/products/bindproducttreewizard"/>
-    
+    <filter root="/apps/commerce/gui/content/products/folderproperties"/>
+
     <!-- We delete the cq:tags search field in the product picker -->
     <filter root="/libs/commerce/gui/content/common/productfield/picker/search/form/tagid"/>
     <filter root="/libs/commerce/gui/content/common/productfield/picker/search/form/tagid-property"/>

--- a/content/cif-virtual-catalog/src/main/content/jcr_root/apps/commerce/gui/content/products/folderproperties/.content.xml
+++ b/content/cif-virtual-catalog/src/main/content/jcr_root/apps/commerce/gui/content/products/folderproperties/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="nt:unstructured"
+        backHref="${granite:concat(&quot;/aem/products.html&quot;, granite:encodeURIPath(granite:relativeParent(empty param.item ? requestPathInfo.suffix : param.item, 1)))}">
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a navigation loop caused by an unusual flow where properties page (configuration properties) is opened from another properties page (folder properties). The Save & Cancel buttons use a `backHref` property which depends on the HTTP header's referer. 

`${empty header.Referer ? granite:concat("/aem/products.html", granite:encodeURIPath(granite:relativeParent(empty param.item ? requestPathInfo.suffix : param.item, 1))) : header.Referer}`

The issue occurs when the user returns to the folder properties page from the configuration properties page because the `backHref` of the Save & Close buttons is set to the referer (configuration page).

The suggested fix is to overlay the `commerce/gui/content/products/folderproperties` with `backHref` set to the product console page (remove dependency on `header.Referer`) (.  Using an overlay instead of directly changing the backHref formula in commerce module preserves original functionality for modules relying directly on `/libs/commerce/gui/content/products/folderproperties`.

## How Has This Been Tested?

- manual testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
