### PR TITLE
CIF-2082 - Use of CatalogDataResourceProviderManager and how to combine with product nodes

### DIFF
--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -99,7 +100,7 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
     private String[] observationPaths = { OBSERVATION_PATHS_DEFAULT, CONF_ROOT };
 
     private static final List<String> WATCHED_PROPERTIES = ImmutableList.of(PN_MAGENTO_STORE, PN_MAGENTO_ROOT_CATEGORY_ID,
-        PN_CATALOG_IDENTIFIER, PN_CATALOG_PROVIDER_FACTORY, PN_GRAPHQL_CLIENT);
+        PN_CATALOG_IDENTIFIER, PN_CATALOG_PROVIDER_FACTORY, PN_GRAPHQL_CLIENT, PN_CONF);
 
     private EventListener[] observationEventListeners;
 
@@ -175,6 +176,10 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
             }
         }
         dataRoots = new CopyOnWriteArrayList<>(allResources);
+        if (log.isDebugEnabled()) {
+            List<String> paths = dataRoots.stream().map(Resource::getPath).collect(Collectors.toList());
+            log.debug("Candidate product data roots found: " + paths);
+        }
     }
 
     private void registerDataRoots() {

--- a/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
+++ b/bundles/cif-virtual-catalog/src/main/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataResourceProviderManagerImpl.java
@@ -184,8 +184,7 @@ public class CatalogDataResourceProviderManagerImpl implements CatalogDataResour
         long countFailed = 0;
 
         findDataRoots(resolver);
-        final List<Resource> existingVirtualCatalogs = dataRoots;
-        for (Resource virtualCatalogRootResource : existingVirtualCatalogs) {
+        for (Resource virtualCatalogRootResource : dataRoots) {
             boolean success = registerDataRoot(virtualCatalogRootResource);
             if (success) {
                 countSuccess++;

--- a/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataProviderManagerConfTest.java
+++ b/bundles/cif-virtual-catalog/src/test/java/com/adobe/cq/commerce/virtual/catalog/data/impl/CatalogDataProviderManagerConfTest.java
@@ -105,11 +105,10 @@ public class CatalogDataProviderManagerConfTest {
         String expectedDataRootPath = COMMERCE_ROOT + "/products/" + NN_DATA_ROOT;
 
         List<Resource> dataRoots = manager.getDataRoots();
-        Assert.assertEquals("The manager found two data roots", 3, dataRoots.size());
+        Assert.assertEquals("The number of data roots found by the manager is not 1", 1, dataRoots.size());
 
         Resource dataRoot = dataRoots.get(0);
         Assert.assertEquals("The data root points to " + expectedDataRootPath, expectedDataRootPath, dataRoot.getPath());
-
     }
 
     private class FactoryConfig {


### PR DESCRIPTION
Avoid calling CatalogDataResourceProviderManagerImpl.findDataRoots() when non binding related nodes are created in /var/commerce/products.
 Added unit test.


## Related Issue

CIF-2082


## How Has This Been Tested?

Manually, unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
