### PR TITLE
CIF-2117: update graphql client version

### DIFF
--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceImplTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/magento/GraphqlDataServiceImplTest.java
@@ -84,11 +84,12 @@ public class GraphqlDataServiceImplTest {
         GraphqlClientConfiguration graphqlClientConfiguration = mock(GraphqlClientConfiguration.class);
         when(graphqlClientConfiguration.httpMethod()).thenReturn(HttpMethod.POST);
         when(graphqlClientConfiguration.identifier()).thenReturn("default");
+        when(graphqlClientConfiguration.maxHttpConnections()).thenReturn(1);
 
         graphqlClient = new GraphqlClientImpl();
+        Utils.activateComponent(graphqlClient, GraphqlClientConfiguration.class, graphqlClientConfiguration);
         Whitebox.setInternalState(graphqlClient, "gson", new Gson());
         Whitebox.setInternalState(graphqlClient, "client", httpClient);
-        Whitebox.setInternalState(graphqlClient, "configuration", graphqlClientConfiguration);
 
         MockGraphqlDataServiceConfiguration config = new MockGraphqlDataServiceConfiguration();
 
@@ -160,9 +161,10 @@ public class GraphqlDataServiceImplTest {
         GraphqlClientConfiguration graphqlClientConfiguration = mock(GraphqlClientConfiguration.class);
         when(graphqlClientConfiguration.httpMethod()).thenReturn(HttpMethod.POST);
         when(graphqlClientConfiguration.identifier()).thenReturn("wrongid");
+        when(graphqlClientConfiguration.maxHttpConnections()).thenReturn(1);
 
         GraphqlClientImpl wrongClient = new GraphqlClientImpl();
-        Whitebox.setInternalState(wrongClient, "configuration", graphqlClientConfiguration);
+        Utils.activateComponent(wrongClient, GraphqlClientConfiguration.class, graphqlClientConfiguration);
         dataService.bindGraphqlClient(wrongClient, null);
 
         Exception exception = null;

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/resource/GraphqlResourceProviderTest.java
@@ -117,11 +117,12 @@ public class GraphqlResourceProviderTest {
 
         GraphqlClientConfiguration graphqlClientConfiguration = mock(GraphqlClientConfiguration.class);
         when(graphqlClientConfiguration.httpMethod()).thenReturn(HttpMethod.POST);
+        when(graphqlClientConfiguration.maxHttpConnections()).thenReturn(1);
 
         GraphqlClient baseClient = new GraphqlClientImpl();
+        Utils.activateComponent(baseClient, GraphqlClientConfiguration.class, graphqlClientConfiguration);
         Whitebox.setInternalState(baseClient, "gson", new Gson());
         Whitebox.setInternalState(baseClient, "client", httpClient);
-        Whitebox.setInternalState(baseClient, "configuration", graphqlClientConfiguration);
 
         GraphqlDataServiceConfiguration config = new MockGraphqlDataServiceConfiguration();
         dataService = new GraphqlDataServiceImpl();

--- a/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/testing/Utils.java
+++ b/bundles/cif-connector-graphql/src/test/java/com/adobe/cq/commerce/graphql/testing/Utils.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.graphql.testing;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -207,5 +208,15 @@ public class Utils {
         Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
 
         return json;
+    }
+
+    /**
+     * Calls the single-argument "activate" osgi lifecycle method on a component instance.
+     */
+    public static <T, C> T activateComponent(T component, Class<C> argumentType, C argument) throws Exception {
+        Method activateMethod = component.getClass().getDeclaredMethod("activate", argumentType);
+        activateMethod.setAccessible(true);
+        activateMethod.invoke(component, argument);
+        return component;
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
         <aem.contextPath />
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.data.file>${project.build.directory}/jacoco.exec</jacoco.data.file>
-        <graphql.client.version>1.7.1</graphql.client.version>
+        <graphql.client.version>1.7.3</graphql.client.version>
         <magento.graphql.version>6.0.0-magento235</magento.graphql.version>
     </properties>
 


### PR DESCRIPTION
The updated version of the graphql client enforces non-infinite socket and connection timeouts.

Do not merge until https://github.com/adobe/commerce-cif-graphql-client/pull/27 is merged and released.